### PR TITLE
various: show build version and commit in settings

### DIFF
--- a/crates/kopuz/assets/tailwind.css
+++ b/crates/kopuz/assets/tailwind.css
@@ -1307,6 +1307,12 @@
       background-color: color-mix(in oklab, var(--color-black) 20%, transparent);
     }
   }
+  .bg-black\/25 {
+    background-color: color-mix(in srgb, #000 25%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-black) 25%, transparent);
+    }
+  }
   .bg-black\/30 {
     background-color: color-mix(in srgb, #000 30%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -2086,6 +2092,12 @@
     color: color-mix(in srgb, #fff 40%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       color: color-mix(in oklab, var(--color-white) 40%, transparent);
+    }
+  }
+  .text-white\/45 {
+    color: color-mix(in srgb, #fff 45%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-white) 45%, transparent);
     }
   }
   .text-white\/50 {

--- a/crates/kopuz/src/logging.rs
+++ b/crates/kopuz/src/logging.rs
@@ -233,7 +233,12 @@ pub fn init(log_dir: &Path, config_tracing_enabled: bool) {
 
     install_panic_hook();
 
-    tracing::info!(log_dir = %log_dir.display(), "logging initialized");
+    tracing::info!(
+        version = utils::build_info::VERSION,
+        commit = utils::build_info::COMMIT,
+        log_dir = %log_dir.display(),
+        "logging initialized"
+    );
 }
 
 /// Chain a panic hook that writes a discrete crash report (panic message +
@@ -265,13 +270,8 @@ fn install_panic_hook() {
             let backtrace = std::backtrace::Backtrace::force_capture().to_string();
 
             if let Some(dir) = utils::logs::log_dir()
-                && let Some(path) = utils::logs::write_crash_report(
-                    &dir,
-                    env!("CARGO_PKG_VERSION"),
-                    &message,
-                    &location,
-                    &backtrace,
-                )
+                && let Some(path) =
+                    utils::logs::write_crash_report(&dir, &message, &location, &backtrace)
             {
                 tracing::error!(crash_report = %path.display(), panic = %message, %location, "panic — crash report written");
             }

--- a/crates/pages/src/settings/mod.rs
+++ b/crates/pages/src/settings/mod.rs
@@ -18,6 +18,37 @@ use dioxus::prelude::*;
 use hooks::use_player_controller::PlayerController;
 
 #[component]
+fn BuildInfoCard() -> Element {
+    let build_summary = utils::build_info::summary();
+    let copy_value = serde_json::to_string(&build_summary).unwrap_or_else(|error| {
+        tracing::warn!(%error, "failed to encode build information for clipboard");
+        "\"\"".to_string()
+    });
+
+    rsx! {
+        aside { class: "mt-4 rounded-xl border border-white/10 bg-black/25 px-5 py-3 flex items-center justify-between gap-5",
+            div { class: "min-w-0 flex flex-col gap-1",
+                span { class: "text-sm font-medium text-white/80", "Kopuz {utils::build_info::VERSION}" }
+                code { class: "text-xs text-white/45 break-all", "{utils::build_info::COMMIT}" }
+            }
+            button {
+                r#type: "button",
+                class: "p-2 rounded text-white/35 hover:text-white hover:bg-white/10 transition-colors shrink-0",
+                title: "{build_summary}",
+                aria_label: "{build_summary}",
+                onclick: move |_| {
+                    let js = format!(
+                        "navigator.clipboard.writeText({copy_value}).catch((e) => console.error('clipboard writeText failed', e));"
+                    );
+                    let _ = dioxus::document::eval(&js);
+                },
+                i { class: "fa-solid fa-copy" }
+            }
+        }
+    }
+}
+
+#[component]
 pub fn Settings(config: Signal<AppConfig>) -> Element {
     let ctrl = use_context::<PlayerController>();
     let spotify_browsers = use_hook(|| {
@@ -678,6 +709,9 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
                         }
                     }
                 }
+                }
+                if active_category() == SettingsCategory::General {
+                    BuildInfoCard {}
                 }
                 if active_category() == SettingsCategory::Customization {
                     {theme_editor_section(config)}

--- a/crates/utils/build.rs
+++ b/crates/utils/build.rs
@@ -1,0 +1,71 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn command_output(repo_root: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn safe_revision(value: &str) -> Option<&str> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'+')))
+    .then_some(value)
+}
+
+fn repo_path(repo_root: &Path, path: &str) -> PathBuf {
+    let path = PathBuf::from(path);
+    if path.is_absolute() {
+        path
+    } else {
+        repo_root.join(path)
+    }
+}
+
+fn watch_git_revision(repo_root: &Path) {
+    if let Some(head) = command_output(repo_root, &["rev-parse", "--git-path", "HEAD"]) {
+        println!(
+            "cargo:rerun-if-changed={}",
+            repo_path(repo_root, &head).display()
+        );
+    }
+
+    if let Some(reference) = command_output(repo_root, &["symbolic-ref", "-q", "HEAD"])
+        && let Some(path) =
+            command_output(repo_root, &["rev-parse", "--git-path", reference.as_str()])
+    {
+        println!(
+            "cargo:rerun-if-changed={}",
+            repo_path(repo_root, &path).display()
+        );
+    }
+}
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=KOPUZ_GIT_COMMIT");
+
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    watch_git_revision(&repo_root);
+
+    let revision = std::env::var("KOPUZ_GIT_COMMIT")
+        .ok()
+        .and_then(|value| safe_revision(&value).map(str::to_owned))
+        .or_else(|| command_output(&repo_root, &["rev-parse", "--verify", "HEAD"]))
+        .and_then(|value| safe_revision(&value).map(str::to_owned))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=KOPUZ_GIT_COMMIT={revision}");
+}

--- a/crates/utils/src/build_info.rs
+++ b/crates/utils/src/build_info.rs
@@ -1,0 +1,12 @@
+//! Compile-time provenance shared by diagnostics and the settings UI.
+
+/// Semantic version of the Kopuz workspace used for this build.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Git revision embedded by `build.rs` or explicitly supplied by the packager.
+pub const COMMIT: &str = env!("KOPUZ_GIT_COMMIT");
+
+/// Text copied from the settings UI and included in diagnostics.
+pub fn summary() -> String {
+    format!("Kopuz {VERSION}\nCommit: {COMMIT}")
+}

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -2,6 +2,7 @@
 //! and terminal logging.
 
 pub mod artist;
+pub mod build_info;
 pub mod color;
 pub mod db_cache;
 pub mod hls_source;

--- a/crates/utils/src/logs.rs
+++ b/crates/utils/src/logs.rs
@@ -12,7 +12,7 @@
 //!     `YYYY-MM-DD_HH-MM-SS`, which sorts alphabetically ==
 //!     chronologically.
 //!   - `crash-<ts>.txt`    — written only on a panic (message + backtrace +
-//!     recent log tail + version/OS).
+//!     recent log tail + version/commit/OS).
 
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -124,11 +124,8 @@ fn read_tail(path: &Path) -> Option<String> {
 }
 
 /// Write a crash report from the panic hook. Returns the path written.
-/// `version` is passed in by the caller because `env!("CARGO_PKG_VERSION")`
-/// here would resolve to `utils`, not the app.
 pub fn write_crash_report(
     dir: &Path,
-    version: &str,
     message: &str,
     location: &str,
     backtrace: &str,
@@ -137,7 +134,8 @@ pub fn write_crash_report(
     let path = dir.join(format!("{CRASH_PREFIX}{ts}.txt"));
     let mut f = std::fs::File::create(&path).ok()?;
     let _ = writeln!(f, "kopuz crash report — {ts} UTC");
-    let _ = writeln!(f, "version: {version}");
+    let _ = writeln!(f, "version: {}", crate::build_info::VERSION);
+    let _ = writeln!(f, "commit: {}", crate::build_info::COMMIT);
     let _ = writeln!(
         f,
         "os: {} / {}",
@@ -185,7 +183,7 @@ pub fn open_log_dir() -> io::Result<()> {
 }
 
 /// Bundle the current session log and the most recent crash report (plus a
-/// version/OS header) into a single file at `dest`, for the user to attach to
+/// version/commit/OS header) into a single file at `dest`, for the user to attach to
 /// a bug report. Triggered by the settings "Export logs" button.
 pub fn export_logs(dest: &Path) -> io::Result<()> {
     let dir =
@@ -206,6 +204,8 @@ pub fn export_logs(dest: &Path) -> io::Result<()> {
 
     let mut out = std::fs::File::create(dest)?;
     writeln!(out, "=== kopuz log export — {} UTC ===", timestamp())?;
+    writeln!(out, "version: {}", crate::build_info::VERSION)?;
+    writeln!(out, "commit: {}", crate::build_info::COMMIT)?;
     writeln!(
         out,
         "os: {} / {}",

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,10 @@
           craneLib = mkCraneLib pkgs;
         in
         {
-          kopuz = pkgs.callPackage ./packaging/nix/crane.nix { inherit craneLib; };
+          kopuz = pkgs.callPackage ./packaging/nix/crane.nix {
+            inherit craneLib;
+            gitRev = self.rev or self.dirtyRev or null;
+          };
           default = self.packages.${system}.kopuz;
         }
       );

--- a/packaging/nix/crane.nix
+++ b/packaging/nix/crane.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   craneLib,
+  gitRev ? null,
   fetchurl,
   pkg-config,
   cmake,
@@ -110,6 +111,9 @@ let
           ]
         );
       };
+  }
+  // lib.optionalAttrs (gitRev != null) {
+    KOPUZ_GIT_COMMIT = gitRev;
   };
 
   # Pre-build all external deps, this derivation is cached across source changes


### PR DESCRIPTION
Shows the version and exact build commit in General settings with copy support. Also includes build provenance in exported logs.

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [ ] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [x] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
