### PR TITLE
fix: get actual cover for playlist instead of first track

### DIFF
--- a/crates/pages/src/home_body.rs
+++ b/crates/pages/src/home_body.rs
@@ -414,7 +414,7 @@ pub fn HomeBody(
                             reader::CoverRef::remote_item(s.service, &p.id, Some(tag.as_str())),
                             384,
                         )
-                        .and_then(|t| Some(t.to_string()))
+                        .map(|t| t.to_string())
                     } else {
                         p.tracks.first().and_then(|tid| {
                             cover_tracks

--- a/crates/pages/src/home_body.rs
+++ b/crates/pages/src/home_body.rs
@@ -401,15 +401,32 @@ pub fn HomeBody(
             .take(10)
             .cloned()
             .map(|p| {
-                let cover_url = p.tracks.first().and_then(|tid| {
-                    cover_tracks
-                        .iter()
-                        .find(|t| {
-                            let id = t.id.key();
-                            !id.is_empty() && id.as_ref() == tid.as_str()
+                let cover_url = {
+                    if let Some(url) =
+                        ::server::cover::from_path(&conf, p.cover_path.as_deref(), 384)
+                    {
+                        Some(url.to_string())
+                    } else if let Some(tag) = &p.image_tag
+                        && let Some(s) = &conf.server
+                    {
+                        ::server::cover::resolve(
+                            &conf,
+                            reader::CoverRef::remote_item(s.service, &p.id, Some(tag.as_str())),
+                            384,
+                        )
+                        .and_then(|t| Some(t.to_string()))
+                    } else {
+                        p.tracks.first().and_then(|tid| {
+                            cover_tracks
+                                .iter()
+                                .find(|t| {
+                                    let id = t.id.key();
+                                    !id.is_empty() && id.as_ref() == tid.as_str()
+                                })
+                                .and_then(|t| track_cover_url(&conf, t))
                         })
-                        .and_then(|t| track_cover_url(&conf, t))
-                });
+                    }
+                };
                 (p.id, p.name, p.tracks.len(), cover_url)
             })
             .collect::<Vec<_>>()


### PR DESCRIPTION
<!--
Please include a clear and concise description of the aim of your pull request
above this line.

If this pull request fixes an open issue, link it with `Fixes #<issue number>`.
For playback, scanning, source, packaging, or crash fixes, include the relevant
logs or reproduction steps.
-->

Copied the playlist cover logic from https://github.com/Kopuz-org/kopuz/blob/master/crates/pages/src/playlists.rs to https://github.com/Kopuz-org/kopuz/blob/master/crates/pages/src/home_body.rs

To have actual playlist covers on home page instead of cover of first track 

## Sanity Checking

<!--
Please check all that apply. These boxes help maintainers quickly understand
what you already verified and what still needs review.
-->

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [x] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
