### PR TITLE
various: stream remote audio with visible buffer progress

### DIFF
--- a/crates/components/src/compact_player.rs
+++ b/crates/components/src/compact_player.rs
@@ -2,6 +2,7 @@ use config::{AppConfig, UiStyle};
 use dioxus::prelude::*;
 use hooks::use_player_controller::PlayerController;
 
+use crate::player_controls::PlaybackBufferIndicator;
 use crate::shared::fmt_time;
 
 /// Global flag toggling the compact mini-player overlay. Provided via context
@@ -78,6 +79,8 @@ pub fn CompactPlayer() -> Element {
 
     let cover = ctrl.current_song_cover_url.read().clone();
     let is_playing = *ctrl.is_playing.read();
+    let is_loading = *ctrl.is_loading.read();
+    let buffered_ranges = ctrl.buffered_ranges.read().clone();
 
     let macos_top = cfg!(target_os = "macos");
 
@@ -154,8 +157,13 @@ pub fn CompactPlayer() -> Element {
             }
 
             div {
-                class: format!("relative z-10 h-[3px] w-full bg-white/10 shrink-0 {}", if is_radio { "" } else { "group cursor-pointer" }),
+                class: format!("relative z-10 h-[3px] w-full bg-white/10 shrink-0 overflow-hidden {}", if is_radio || is_loading { "" } else { "group cursor-pointer" }),
                 onmousedown: move |evt| evt.stop_propagation(),
+                PlaybackBufferIndicator {
+                    ranges: buffered_ranges,
+                    played_percent: progress_percent,
+                    loading: is_loading,
+                }
                 div {
                     class: format!("absolute top-0 left-0 h-full pointer-events-none {}", skin.progress_fill),
                     style: "width: {progress_percent}%",
@@ -165,8 +173,8 @@ pub fn CompactPlayer() -> Element {
                     min: "0",
                     max: "{duration}",
                     value: "{display_progress}",
-                    class: format!("slider-hit absolute top-0 left-0 w-full h-full opacity-0 z-10 {}", if is_radio { "pointer-events-none" } else { "cursor-pointer" }),
-                    disabled: is_radio,
+                    class: format!("slider-hit absolute top-0 left-0 w-full h-full opacity-0 z-10 {}", if is_radio || is_loading { "pointer-events-none" } else { "cursor-pointer" }),
+                    disabled: is_radio || is_loading,
                     onchange: move |evt| {
                         if let Ok(val) = evt.value().parse::<f64>().map(|v| v as u64) {
                             ctrl.seek(std::time::Duration::from_secs(val));

--- a/crates/components/src/normal/bottombar.rs
+++ b/crates/components/src/normal/bottombar.rs
@@ -1,5 +1,7 @@
 use crate::NavigationController;
-use crate::player_controls::{ControlsVariant, SeekSlider, TransportButtons, VolumeSlider};
+use crate::player_controls::{
+    ControlsVariant, PlaybackBufferIndicator, SeekSlider, TransportButtons, VolumeSlider,
+};
 use config::PlayerBarPosition;
 use dioxus::prelude::*;
 use hooks::use_player_controller::PlayerController;
@@ -33,6 +35,8 @@ pub fn BottombarNormal(
     let crate::CompactMode(mut compact_mode) = use_context::<crate::CompactMode>();
 
     if cfg!(target_os = "android") {
+        let is_loading = *ctrl.is_loading.read();
+        let buffered_ranges = ctrl.buffered_ranges.read().clone();
         let progress_percent = if *current_song_duration.read() > 0 {
             (*current_song_progress.read() as f64 / *current_song_duration.read() as f64) * 100.0
         } else {
@@ -43,7 +47,12 @@ pub fn BottombarNormal(
             div {
                 class: "shrink-0 mx-2 mb-[env(safe-area-inset-bottom)] h-[68px] bg-[#121212]/95 backdrop-blur-3xl border border-white/10 rounded-[24px] flex items-center px-3 gap-3 relative overflow-hidden shadow-[0_12px_40px_rgba(0,0,0,0.8)]",
                 onclick: move |_| is_fullscreen.set(true),
-                div { class: "absolute top-0 left-0 h-[2px] bg-white/10 w-full",
+                div { class: "absolute top-0 left-0 h-[2px] bg-white/10 w-full overflow-hidden",
+                    PlaybackBufferIndicator {
+                        ranges: buffered_ranges,
+                        played_percent: progress_percent,
+                        loading: is_loading,
+                    }
                     div { class: "h-full bg-white transition-all duration-300", style: "width: {progress_percent}%" }
                 }
                 div { class: "w-11 h-11 bg-white/5 rounded-xl shrink-0 overflow-hidden flex items-center justify-center",

--- a/crates/components/src/player_controls.rs
+++ b/crates/components/src/player_controls.rs
@@ -1,7 +1,7 @@
 use crate::shared::fmt_time;
 use config::AppConfig;
 use dioxus::prelude::*;
-use hooks::use_player_controller::{LoopMode, PlayerController};
+use hooks::use_player_controller::{BufferedRange, LoopMode, PlayerController};
 use player::player::Player;
 
 pub struct SeekDrag {
@@ -10,6 +10,61 @@ pub struct SeekDrag {
     pub is_radio: bool,
     pub on_commit: Callback<FormEvent>,
     pub on_input: Callback<FormEvent>,
+}
+
+/// Network bytes already fetched, drawn behind the played position. Before
+/// byte totals arrive, an indeterminate scan confirms that loading is active.
+#[component]
+pub(crate) fn PlaybackBufferIndicator(
+    ranges: Vec<BufferedRange>,
+    played_percent: f64,
+    loading: bool,
+) -> Element {
+    let visual_ranges = visual_buffer_ranges(&ranges, played_percent);
+    rsx! {
+        div {
+            class: "absolute inset-0 overflow-hidden rounded-full pointer-events-none",
+            "aria-hidden": "true",
+            for (left, right) in visual_ranges {
+                div {
+                    class: "absolute top-0 h-full bg-white/30 rounded-full",
+                    style: "left: {left}%; width: {right - left}%;"
+                }
+            }
+            if loading && ranges.is_empty() {
+                div {
+                    class: "h-full w-1/4 bg-[var(--color-primary,#6366f1)] animate-scan"
+                }
+            }
+        }
+    }
+}
+
+fn visual_buffer_ranges(ranges: &[BufferedRange], played_percent: f64) -> Vec<(f64, f64)> {
+    const MERGE_GAP_PERCENT: f64 = 0.75;
+    const PLAYHEAD_SNAP_PERCENT: f64 = 5.0;
+
+    let mut visual: Vec<(f64, f64)> = Vec::with_capacity(ranges.len());
+    for range in ranges {
+        let start = (range.start as f64 / range.total as f64 * 100.0).clamp(0.0, 100.0);
+        let end = (range.end as f64 / range.total as f64 * 100.0).clamp(start, 100.0);
+        if let Some(previous) = visual.last_mut()
+            && start - previous.1 <= MERGE_GAP_PERCENT
+        {
+            previous.1 = previous.1.max(end);
+        } else {
+            visual.push((start, end));
+        }
+    }
+
+    let played_percent = played_percent.clamp(0.0, 100.0);
+    if let Some(active) = visual.iter_mut().find(|(start, end)| {
+        *end >= played_percent && *start <= played_percent + PLAYHEAD_SNAP_PERCENT
+    }) && active.0 > played_percent
+    {
+        active.0 = played_percent;
+    }
+    visual
 }
 
 pub fn use_seek_drag(
@@ -260,12 +315,16 @@ pub fn SeekSlider(
     current_song_progress: Signal<u64>,
     variant: ControlsVariant,
 ) -> Element {
+    let ctrl = use_context::<PlayerController>();
     let seek = use_seek_drag(current_song_duration, current_song_progress);
     let display_progress = seek.display_progress;
     let progress_percent = seek.progress_percent;
     let is_radio = seek.is_radio;
     let on_commit = seek.on_commit;
     let on_input = seek.on_input;
+    let is_loading = *ctrl.is_loading.read();
+    let buffered_ranges = ctrl.buffered_ranges.read().clone();
+    let can_seek = !is_radio && !is_loading;
 
     match variant {
         ControlsVariant::Fullscreen => rsx! {
@@ -276,31 +335,42 @@ pub fn SeekSlider(
                     class: "flex items-center gap-3",
                     span { class: "text-xs text-white/70 font-mono", style: "width: 50px; text-align: left;", "{fmt_time(display_progress)}" }
                     div {
-                        class: format!("flex-1 {} relative group", if is_radio { "" } else { "cursor-pointer" }),
+                        class: format!("flex-1 {} relative group", if can_seek { "cursor-pointer" } else { "" }),
                         style: "height: 20px;",
                         div {
                             class: "absolute bg-white/20 rounded-full",
                             style: "height: 4px; top: 8px; left: 0; right: 0;"
                         }
                         div {
+                            class: "absolute overflow-hidden rounded-full",
+                            style: "height: 4px; top: 8px; left: 0; right: 0;",
+                            PlaybackBufferIndicator {
+                                ranges: buffered_ranges.clone(),
+                                played_percent: progress_percent,
+                                loading: is_loading,
+                            }
+                        }
+                        div {
                             class: "absolute rounded-full pointer-events-none bg-white/90",
                             style: "height: 4px; top: 8px; left: 0; width: {progress_percent}%;"
                         }
-                        div {
-                            class: if cfg!(target_os = "android") {
-                                "absolute bg-white rounded-full pointer-events-none"
-                            } else {
-                                "absolute bg-white rounded-full pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity"
-                            },
-                            style: "width: 12px; height: 12px; top: 4px; left: calc({progress_percent}% - 6px);"
+                        if !is_loading {
+                            div {
+                                class: if cfg!(target_os = "android") {
+                                    "absolute bg-white rounded-full pointer-events-none"
+                                } else {
+                                    "absolute bg-white rounded-full pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity"
+                                },
+                                style: "width: 12px; height: 12px; top: 4px; left: calc({progress_percent}% - 6px);"
+                            }
                         }
                         input {
                             r#type: "range",
                             min: "0",
                             max: "{*current_song_duration.read()}",
                             value: "{display_progress}",
-                            class: format!("slider-hit absolute top-0 left-0 w-full h-full opacity-0 {}", if is_radio { "" } else { "cursor-pointer" }),
-                            disabled: is_radio,
+                            class: format!("slider-hit absolute top-0 left-0 w-full h-full opacity-0 {}", if can_seek { "cursor-pointer" } else { "" }),
+                            disabled: !can_seek,
                             onchange: move |evt| on_commit.call(evt),
                             oninput: move |evt| on_input.call(evt),
                         }
@@ -314,19 +384,24 @@ pub fn SeekSlider(
                 class: "flex items-center gap-2 w-full",
                 span { class: "text-[10px] text-slate-500 w-8 text-right font-mono", "{fmt_time(display_progress)}" }
                 div {
-                    class: format!("flex-1 h-1 bg-white/10 rounded-full relative {}", if is_radio { "" } else { "group cursor-pointer" }),
+                    class: format!("flex-1 h-1 bg-white/10 rounded-full relative {}", if can_seek { "group cursor-pointer" } else { "" }),
+                    PlaybackBufferIndicator {
+                        ranges: buffered_ranges.clone(),
+                        played_percent: progress_percent,
+                        loading: is_loading,
+                    }
                     div {
                         class: "absolute top-0 left-0 h-full bg-white/90 rounded-full pointer-events-none",
                         style: "width: {progress_percent}%",
-                        div { class: "absolute -right-1.5 -top-1 w-3 h-3 bg-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity" }
+                            div { class: "absolute -right-1.5 -top-1 w-3 h-3 bg-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity" }
                     }
                     input {
                         r#type: "range",
                         min: "0",
                         max: "{*current_song_duration.read()}",
                         value: "{display_progress}",
-                        class: format!("slider-hit absolute top-0 left-0 w-full h-full opacity-0 z-10 {}", if is_radio { "pointer-events-none" } else { "cursor-pointer" }),
-                        disabled: is_radio,
+                        class: format!("slider-hit absolute top-0 left-0 w-full h-full opacity-0 z-10 {}", if can_seek { "cursor-pointer" } else { "pointer-events-none" }),
+                        disabled: !can_seek,
                         onchange: move |evt| on_commit.call(evt),
                         oninput: move |evt| on_input.call(evt),
                     }
@@ -421,5 +496,49 @@ pub fn VolumeSlider(
                 }
             }
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BufferedRange, visual_buffer_ranges};
+
+    #[test]
+    fn buffer_display_coalesces_small_gaps_and_attaches_to_playhead() {
+        let ranges = vec![
+            BufferedRange {
+                start: 680,
+                end: 700,
+                total: 1_000,
+            },
+            BufferedRange {
+                start: 704,
+                end: 720,
+                total: 1_000,
+            },
+        ];
+
+        assert_eq!(visual_buffer_ranges(&ranges, 65.0), vec![(65.0, 72.0)]);
+    }
+
+    #[test]
+    fn buffer_display_keeps_distant_seek_ranges_separate() {
+        let ranges = vec![
+            BufferedRange {
+                start: 100,
+                end: 200,
+                total: 1_000,
+            },
+            BufferedRange {
+                start: 800,
+                end: 900,
+                total: 1_000,
+            },
+        ];
+
+        assert_eq!(
+            visual_buffer_ranges(&ranges, 10.0),
+            vec![(10.0, 20.0), (80.0, 90.0)]
+        );
     }
 }

--- a/crates/components/src/vaxry/bottombar.rs
+++ b/crates/components/src/vaxry/bottombar.rs
@@ -1,5 +1,7 @@
 use crate::NavigationController;
-use crate::player_controls::{ControlsVariant, SeekSlider, TransportButtons, VolumeSlider};
+use crate::player_controls::{
+    ControlsVariant, PlaybackBufferIndicator, SeekSlider, TransportButtons, VolumeSlider,
+};
 use config::PlayerBarPosition;
 use dioxus::prelude::*;
 use hooks::use_player_controller::PlayerController;
@@ -32,6 +34,8 @@ pub fn BottombarVaxry(
     let is_fav = hooks::use_db_queries::use_track_is_favorite(fav_track);
     let crate::CompactMode(mut compact_mode) = use_context::<crate::CompactMode>();
     if cfg!(target_os = "android") {
+        let is_loading = *ctrl.is_loading.read();
+        let buffered_ranges = ctrl.buffered_ranges.read().clone();
         let pct = if *current_song_duration.read() > 0 {
             (*current_song_progress.read() as f64 / *current_song_duration.read() as f64) * 100.0
         } else {
@@ -43,7 +47,12 @@ pub fn BottombarVaxry(
             div {
                 class: "shrink-0 h-[68px] bg-black/85 backdrop-blur-2xl border-t border-white/10 flex items-center px-3 gap-3 relative overflow-hidden mb-[env(safe-area-inset-bottom)]",
                 onclick: move |_| is_fullscreen.set(true),
-                div { class: "absolute top-0 left-0 h-[2px] bg-white/10 w-full",
+                div { class: "absolute top-0 left-0 h-[2px] bg-white/10 w-full overflow-hidden",
+                    PlaybackBufferIndicator {
+                        ranges: buffered_ranges,
+                        played_percent: pct,
+                        loading: is_loading,
+                    }
                     div { class: "h-full bg-white/80 transition-all duration-300", style: "width: {pct}%" }
                 }
                 div { class: "w-11 h-11 bg-white/5 rounded shrink-0 overflow-hidden flex items-center justify-center",

--- a/crates/hooks/src/use_player_controller.rs
+++ b/crates/hooks/src/use_player_controller.rs
@@ -4,6 +4,7 @@ use dioxus::{logger::tracing, prelude::*};
 use player::engine::{SourceFactory, Transition};
 use player::player::{LoadArgs, NowPlayingMeta, Player};
 use reader::Track;
+use std::sync::Arc;
 use std::time::Duration;
 use utils;
 
@@ -81,6 +82,10 @@ pub struct PlayerController {
     pub current_song_bitrate: Signal<u16>,
     pub current_song_duration: Signal<u64>,
     pub current_song_progress: Signal<u64>,
+    /// Byte ranges already fetched for the active network track. The UI draws
+    /// these behind playback position, like a browser media seek bar.
+    pub buffered_ranges: Signal<Vec<BufferedRange>>,
+    buffer_progress_tx: Signal<tokio::sync::mpsc::UnboundedSender<BufferProgressEvent>>,
     pub current_song_cover_url: Signal<String>,
     pub current_track_snapshot: Signal<Option<Track>>,
     pub volume: Signal<f32>,
@@ -171,7 +176,63 @@ pub struct PendingCrossfadeUiState {
     pub from_token: u64,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BufferedRange {
+    pub start: u64,
+    pub end: u64,
+    pub total: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BufferProgressEvent {
+    token: u64,
+    start: u64,
+    end: u64,
+    total: Option<u64>,
+}
+
+fn merge_buffered_range(ranges: &mut Vec<BufferedRange>, incoming: BufferedRange) {
+    if incoming.total == 0 || incoming.start >= incoming.end {
+        return;
+    }
+    if ranges
+        .first()
+        .is_some_and(|range| range.total != incoming.total)
+    {
+        ranges.clear();
+    }
+    ranges.push(BufferedRange {
+        end: incoming.end.min(incoming.total),
+        ..incoming
+    });
+    ranges.sort_unstable_by_key(|range| range.start);
+
+    let mut merged: Vec<BufferedRange> = Vec::with_capacity(ranges.len());
+    for range in ranges.drain(..) {
+        if let Some(previous) = merged.last_mut()
+            && range.start <= previous.end
+        {
+            previous.end = previous.end.max(range.end);
+            continue;
+        }
+        merged.push(range);
+    }
+    *ranges = merged;
+}
+
 impl PlayerController {
+    fn buffer_progress_callback(&self, token: u64) -> utils::stream_buffer::BufferProgressCallback {
+        let progress_tx = self.buffer_progress_tx.peek().clone();
+        Arc::new(move |start, end, total| {
+            let _ = progress_tx.send(BufferProgressEvent {
+                token,
+                start,
+                end,
+                total,
+            });
+        })
+    }
+
     fn track_key(track: &Track) -> String {
         track.id.uid().to_string()
     }
@@ -365,6 +426,7 @@ impl PlayerController {
         self.current_song_bitrate.set(0);
         self.current_song_duration.set(0);
         self.current_song_progress.set(0);
+        self.buffered_ranges.set(Vec::new());
         self.current_song_cover_url.set(String::new());
         self.current_track_snapshot.set(None);
     }
@@ -583,6 +645,7 @@ impl PlayerController {
         }
         self.playback_error
             .set(Some(format!("Couldn't load this track:\n{error}")));
+        self.buffered_ranges.set(Vec::new());
         match intent {
             PlaybackIntent::Loading {
                 crossfade: true,
@@ -1091,6 +1154,7 @@ impl PlayerController {
             crossfade: use_crossfade,
             from_token,
         });
+        self.buffered_ranges.set(Vec::new());
 
         let cover_url: String = if offline_path.is_some() {
             self.cover_url_for_track(&track)
@@ -1141,6 +1205,8 @@ impl PlayerController {
                 } else {
                     (None, None)
                 };
+                let buffer_progress = (!is_radio_item)
+                    .then(|| ctrl.buffer_progress_callback(token));
 
                 let factory: SourceFactory = if let Some(path) = local_path {
                     Box::new(move || decoder::open_file(&path).map_err(|e| e.to_string()))
@@ -1164,6 +1230,7 @@ impl PlayerController {
                                 false,
                                 None,
                                 rt_handle.clone(),
+                                buffer_progress.clone(),
                             )()
                         }
                     })
@@ -1209,6 +1276,7 @@ impl PlayerController {
                         is_radio_item,
                         icy_tx,
                         rt_handle,
+                        buffer_progress,
                     )
                 };
 
@@ -1315,6 +1383,7 @@ fn network_factory(
     is_radio: bool,
     icy_tx: Option<tokio::sync::watch::Sender<utils::icy::IcyMeta>>,
     rt_handle: tokio::runtime::Handle,
+    buffer_progress: Option<utils::stream_buffer::BufferProgressCallback>,
 ) -> SourceFactory {
     Box::new(move || {
         let build = || -> std::io::Result<_> {
@@ -1332,8 +1401,11 @@ fn network_factory(
                     // YT: HTTP Range-backed source. Symphonia can seek freely
                     // (Matroska Cues at the end, scrub anywhere) and startup
                     // probes only fetch the ~512 KiB they need.
-                    let range =
-                        utils::range_source::RangeStreamSource::new(stream_url, yt_user_agent)?;
+                    let range = utils::range_source::RangeStreamSource::new_with_progress(
+                        stream_url,
+                        yt_user_agent,
+                        buffer_progress,
+                    )?;
                     let len = Some(range.total_size());
                     let (source, mut hint) = decoder::from_stream_with_len(range, len);
                     hint.with_extension(fmt.extension());
@@ -1342,14 +1414,15 @@ fn network_factory(
                     // No-pot fallback: googlevideo 403s deep ranges, and the
                     // probe reads the webm tail — stream sequentially instead of
                     // failing outright (issue #386). No scrubbing.
-                    let stream = utils::stream_buffer::StreamBuffer::with_user_agent(
+                    let stream = utils::stream_buffer::StreamBuffer::with_user_agent_and_progress(
                         stream_url,
                         false,
                         yt_user_agent,
                         None,
                         rt_handle,
+                        buffer_progress,
                     );
-                    stream.wait_for_total_size();
+                    stream.wait_for_response_headers();
                     let len = stream.known_total_size();
                     let (source, mut hint) = decoder::from_stream_with_len(stream, len);
                     hint.with_extension(fmt.extension());
@@ -1367,16 +1440,35 @@ fn network_factory(
                 hint.with_extension("m4a");
                 Ok((source, hint))
             } else {
-                let stream = utils::stream_buffer::StreamBuffer::with_user_agent(
-                    stream_url,
-                    false,
-                    yt_user_agent,
-                    None,
-                    rt_handle,
-                );
-                stream.wait_for_total_size();
-                let len = stream.known_total_size();
-                Ok(decoder::from_stream_with_len(stream, len))
+                // Jellyfin and Subsonic/Navidrome normally support HTTP
+                // ranges. Let format probes jump straight to tail metadata
+                // instead of making a sequential buffer download everything
+                // between the start and end of the file.
+                match utils::range_source::RangeStreamSource::new_with_progress(
+                    stream_url.clone(),
+                    yt_user_agent.clone(),
+                    buffer_progress.clone(),
+                ) {
+                    Ok(range) => {
+                        let len = Some(range.total_size());
+                        Ok(decoder::from_stream_with_len(range, len))
+                    }
+                    Err(error) => {
+                        tracing::debug!(%error, "HTTP ranges unavailable; using progressive stream");
+                        let stream =
+                            utils::stream_buffer::StreamBuffer::with_user_agent_and_progress(
+                                stream_url,
+                                false,
+                                yt_user_agent,
+                                None,
+                                rt_handle,
+                                buffer_progress,
+                            );
+                        stream.wait_for_response_headers();
+                        let len = stream.known_total_size();
+                        Ok(decoder::from_stream_with_len(stream, len))
+                    }
+                }
             }
         };
         build().map_err(|e| e.to_string())
@@ -1406,6 +1498,39 @@ pub fn use_player_controller(
     let intent = use_signal(|| PlaybackIntent::Stopped);
     let next_token = use_signal(|| 0u64);
     let current_token = use_signal(|| 0u64);
+    let buffered_ranges = use_signal(Vec::<BufferedRange>::new);
+    let (progress_tx, progress_rx) = use_hook(|| {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<BufferProgressEvent>();
+        (tx, std::rc::Rc::new(std::cell::RefCell::new(Some(rx))))
+    });
+    let buffer_progress_tx = use_signal(move || progress_tx);
+    let progress_rx_slot = progress_rx.clone();
+    let mut buffered_ranges_sink = buffered_ranges;
+    use_effect(move || {
+        let Some(mut progress_rx) = progress_rx_slot.borrow_mut().take() else {
+            return;
+        };
+        spawn(async move {
+            while let Some(event) = progress_rx.recv().await {
+                if *current_token.peek() != event.token {
+                    continue;
+                }
+                let Some(total) = event.total.filter(|total| *total > 0) else {
+                    continue;
+                };
+                buffered_ranges_sink.with_mut(|ranges| {
+                    merge_buffered_range(
+                        ranges,
+                        BufferedRange {
+                            start: event.start,
+                            end: event.end,
+                            total,
+                        },
+                    );
+                });
+            }
+        });
+    });
     let armed_transition = use_signal(|| None);
     let browse_loading = use_signal(|| false);
     let is_loading = use_memo(move || intent.read().is_loading() || *browse_loading.read());
@@ -1482,6 +1607,8 @@ pub fn use_player_controller(
         current_song_bitrate,
         current_song_duration,
         current_song_progress,
+        buffered_ranges,
+        buffer_progress_tx,
         current_song_cover_url,
         current_track_snapshot,
         volume,
@@ -1510,5 +1637,73 @@ pub fn use_player_controller(
         spotify_commanded,
         external_active,
         spotify_device_chosen,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BufferedRange, merge_buffered_range};
+
+    #[test]
+    fn buffered_ranges_merge_adjacent_and_overlapping_chunks() {
+        let mut ranges = Vec::new();
+        for (start, end) in [(500, 750), (0, 250), (200, 500)] {
+            merge_buffered_range(
+                &mut ranges,
+                BufferedRange {
+                    start,
+                    end,
+                    total: 1_000,
+                },
+            );
+        }
+
+        assert_eq!(
+            ranges,
+            vec![BufferedRange {
+                start: 0,
+                end: 750,
+                total: 1_000,
+            }]
+        );
+    }
+
+    #[test]
+    fn buffered_ranges_preserve_gaps_and_reset_for_a_new_total() {
+        let mut ranges = Vec::new();
+        merge_buffered_range(
+            &mut ranges,
+            BufferedRange {
+                start: 0,
+                end: 100,
+                total: 1_000,
+            },
+        );
+        merge_buffered_range(
+            &mut ranges,
+            BufferedRange {
+                start: 900,
+                end: 1_000,
+                total: 1_000,
+            },
+        );
+        assert_eq!(ranges.len(), 2);
+
+        merge_buffered_range(
+            &mut ranges,
+            BufferedRange {
+                start: 0,
+                end: 50,
+                total: 500,
+            },
+        );
+        assert_eq!(
+            ranges,
+            vec![BufferedRange {
+                start: 0,
+                end: 50,
+                total: 500,
+            }]
+        );
     }
 }

--- a/crates/kopuz/assets/tailwind.css
+++ b/crates/kopuz/assets/tailwind.css
@@ -1472,6 +1472,12 @@
       background-color: color-mix(in oklab, var(--color-white) 20%, transparent);
     }
   }
+  .bg-white\/30 {
+    background-color: color-mix(in srgb, #fff 30%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 30%, transparent);
+    }
+  }
   .bg-white\/40 {
     background-color: color-mix(in srgb, #fff 40%, transparent);
     @supports (color: color-mix(in lab, red, red)) {

--- a/crates/player/src/decoder.rs
+++ b/crates/player/src/decoder.rs
@@ -67,7 +67,15 @@ pub fn from_stream_with_len(
     stream: impl Read + Seek + Send + Sync + 'static,
     len: Option<u64>,
 ) -> (Box<dyn MediaSource>, Hint) {
-    let source: Box<dyn MediaSource> = Box::new(ReadSeekSource::new(Box::new(stream), len));
+    let source: Box<dyn MediaSource> = match len {
+        Some(len) => Box::new(ReadSeekSource::new(Box::new(stream), Some(len))),
+        // Without a total length, end-relative seeks cannot be implemented
+        // correctly while the HTTP body is still arriving. Treat the source as
+        // progressive instead of making a probe wait for the full download.
+        None => Box::new(ReadOnlySource {
+            inner: Box::new(stream),
+        }),
+    };
     let hint = Hint::new();
     (source, hint)
 }
@@ -114,4 +122,25 @@ pub fn from_stream_with_hint(
     let mut hint = Hint::new();
     hint.with_extension(extension);
     (source, hint)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_with_known_length_is_seekable() {
+        let (source, _) = from_stream_with_len(std::io::Cursor::new(vec![0; 8]), Some(8));
+
+        assert!(source.is_seekable());
+        assert_eq!(source.byte_len(), Some(8));
+    }
+
+    #[test]
+    fn stream_without_length_is_progressive() {
+        let (source, _) = from_stream_with_len(std::io::Cursor::new(vec![0; 8]), None);
+
+        assert!(!source.is_seekable());
+        assert_eq!(source.byte_len(), None);
+    }
 }

--- a/crates/utils/src/range_source.rs
+++ b/crates/utils/src/range_source.rs
@@ -1,6 +1,6 @@
 //! HTTP Range-backed seekable byte source.
 //!
-//! Used for YouTube Music (and any other URL where the server returns
+//! Used for remote media servers and YouTube Music when the URL returns
 //! `Accept-Ranges: bytes`). Unlike [`crate::stream_buffer::StreamBuffer`],
 //! this never downloads the file linearly — every miss in the rolling
 //! window cache becomes a `Range: bytes=N-M` request. Symphonia can seek
@@ -17,11 +17,13 @@
 //!   thread (`spawn_blocking` or similar).
 //!
 //! `byte_len()` is determined once upfront from `Content-Range` of the
-//! initial probe fetch. If the server doesn't include it, we fall back to
-//! a HEAD request. If both fail, this source can't be constructed.
+//! initial probe fetch. If the server ignores ranges or omits the total,
+//! this source can't be constructed and the caller can stream sequentially.
 
 use std::io::{Error as IoError, ErrorKind, Read, Result as IoResult, Seek, SeekFrom};
 use std::time::Duration;
+
+use crate::stream_buffer::BufferProgressCallback;
 
 const CHUNK: usize = 512 * 1024;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
@@ -33,6 +35,7 @@ pub struct RangeStreamSource {
     pos: u64,
     chunk: Vec<u8>,
     chunk_start: u64,
+    progress: Option<BufferProgressCallback>,
 }
 
 impl RangeStreamSource {
@@ -40,6 +43,14 @@ impl RangeStreamSource {
     /// total size and confirm Range support. Returns the source positioned
     /// at byte 0 with an empty cache.
     pub fn new(url: String, user_agent: Option<String>) -> IoResult<Self> {
+        Self::new_with_progress(url, user_agent, None)
+    }
+
+    pub fn new_with_progress(
+        url: String,
+        user_agent: Option<String>,
+        progress: Option<BufferProgressCallback>,
+    ) -> IoResult<Self> {
         let ua =
             user_agent.unwrap_or_else(|| concat!("Kopuz/", env!("CARGO_PKG_VERSION")).to_string());
         let client = reqwest::blocking::Client::builder()
@@ -57,11 +68,14 @@ impl RangeStreamSource {
             .send()
             .map_err(IoError::other)?;
         let status = resp.status();
-        if !status.is_success() {
-            return Err(IoError::other(format!("range probe HTTP {status}")));
+        if status != reqwest::StatusCode::PARTIAL_CONTENT {
+            return Err(IoError::new(
+                ErrorKind::Unsupported,
+                format!("server ignored range probe (HTTP {status})"),
+            ));
         }
         let total_size = parse_total_size(&resp)
-            .ok_or_else(|| IoError::other("server didn't expose total size on range probe"))?;
+            .ok_or_else(|| IoError::other("range response didn't expose total size"))?;
 
         Ok(Self {
             url,
@@ -70,6 +84,7 @@ impl RangeStreamSource {
             pos: 0,
             chunk: Vec::with_capacity(CHUNK),
             chunk_start: 0,
+            progress,
         })
     }
 
@@ -85,16 +100,29 @@ impl RangeStreamSource {
             .header("Range", format!("bytes={start}-{end}"))
             .send()
             .map_err(IoError::other)?;
-        if !resp.status().is_success() {
+        if resp.status() != reqwest::StatusCode::PARTIAL_CONTENT {
             return Err(IoError::other(format!(
-                "range fetch {start}-{end} HTTP {}",
+                "range fetch {start}-{end} expected HTTP 206, got {}",
                 resp.status()
             )));
         }
         let bytes = resp.bytes().map_err(IoError::other)?;
+        let expected = (end - start + 1) as usize;
+        if bytes.len() != expected {
+            return Err(IoError::new(
+                ErrorKind::UnexpectedEof,
+                format!(
+                    "range fetch {start}-{end} returned {} bytes, expected {expected}",
+                    bytes.len()
+                ),
+            ));
+        }
         self.chunk.clear();
         self.chunk.extend_from_slice(&bytes);
         self.chunk_start = start;
+        if let Some(progress) = &self.progress {
+            progress(start, end + 1, Some(self.total_size));
+        }
         Ok(())
     }
 
@@ -144,20 +172,38 @@ impl Seek for RangeStreamSource {
 }
 
 fn parse_total_size(resp: &reqwest::blocking::Response) -> Option<u64> {
-    // Prefer Content-Range: "bytes 0-0/12345" — the part after '/' is the
-    // total. Fall back to Content-Length only if Range wasn't honoured (in
-    // which case the server gave us the whole body, and Content-Length is
-    // the full file size).
-    if let Some(v) = resp.headers().get("content-range")
-        && let Ok(s) = v.to_str()
-        && let Some(slash) = s.rfind('/')
-    {
-        let tail = &s[slash + 1..];
-        if tail != "*"
-            && let Ok(n) = tail.parse()
-        {
-            return Some(n);
-        }
+    // Content-Range: "bytes 0-0/12345" — the part after '/' is the total.
+    // Content-Length on this 206 response is only the one-byte probe length.
+    resp.headers()
+        .get("content-range")
+        .and_then(|value| value.to_str().ok())
+        .and_then(total_size_from_content_range)
+}
+
+fn total_size_from_content_range(value: &str) -> Option<u64> {
+    let (_, total) = value.rsplit_once('/')?;
+    if total == "*" {
+        return None;
     }
-    resp.content_length()
+    total.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::total_size_from_content_range;
+
+    #[test]
+    fn parses_total_from_content_range() {
+        assert_eq!(
+            total_size_from_content_range("bytes 0-0/123456"),
+            Some(123_456)
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_or_malformed_content_range_totals() {
+        assert_eq!(total_size_from_content_range("bytes 0-0/*"), None);
+        assert_eq!(total_size_from_content_range("bytes 0-0/not-a-size"), None);
+        assert_eq!(total_size_from_content_range("123456"), None);
+    }
 }

--- a/crates/utils/src/stream_buffer.rs
+++ b/crates/utils/src/stream_buffer.rs
@@ -18,6 +18,11 @@ const MIN_PREBUFFER_BYTES: usize = 256 * 1024; // 256KB
 const MIN_BUFFER_AHEAD: usize = 128 * 1024; // 128KB
 
 const MAX_BUFFER_SIZE: usize = 1024 * 1024 * 1024; // 1GB
+const PROGRESS_REPORT_STEP: usize = 64 * 1024;
+
+/// Reports one downloaded byte range as `[start, end)` plus the total length
+/// when the server exposes it.
+pub type BufferProgressCallback = Arc<dyn Fn(u64, u64, Option<u64>) + Send + Sync>;
 
 /// Shared state between the async downloader and sync readers.
 ///
@@ -26,12 +31,14 @@ const MAX_BUFFER_SIZE: usize = 1024 * 1024 * 1024; // 1GB
 /// - `done`: HTTP stream finished (success or error)
 /// - `error`: reason for failure, if any
 /// - `total_size`: Content-Length header value (may be unknown for radio/streams)
+/// - `response_ready`: response headers arrived, even when no Content-Length exists
 /// - `prebuffer_ready`: enough data buffered to start playback safely
 struct SharedState {
     buffer: Vec<u8>,
     done: bool,
     error: Option<String>,
     total_size: Option<u64>,
+    response_ready: bool,
     prebuffer_ready: bool,
 }
 
@@ -55,6 +62,17 @@ impl StreamBuffer {
         icy_tx: Option<tokio::sync::watch::Sender<crate::icy::IcyMeta>>,
         runtime: tokio::runtime::Handle,
     ) -> Self {
+        Self::with_user_agent_and_progress(url, is_radio, user_agent, icy_tx, runtime, None)
+    }
+
+    pub fn with_user_agent_and_progress(
+        url: String,
+        is_radio: bool,
+        user_agent: Option<String>,
+        icy_tx: Option<tokio::sync::watch::Sender<crate::icy::IcyMeta>>,
+        runtime: tokio::runtime::Handle,
+        progress: Option<BufferProgressCallback>,
+    ) -> Self {
         let prebuffer_size = if is_radio {
             16 * 1024
         } else {
@@ -67,6 +85,7 @@ impl StreamBuffer {
                 done: false,
                 error: None,
                 total_size: None,
+                response_ready: false,
                 prebuffer_ready: false,
             }),
             Notify::new(),
@@ -144,6 +163,7 @@ impl StreamBuffer {
                             let (lock, notify) = &*state_clone;
                             let mut state = lock.lock().await;
                             state.total_size = total_size;
+                            state.response_ready = true;
                             notify.notify_waiters();
                         }
 
@@ -161,6 +181,7 @@ impl StreamBuffer {
                         });
 
                         let mut total_buffered = 0usize;
+                        let mut last_progress_report = 0usize;
                         let mut audio_scratch = Vec::new();
 
                         while let Ok(Some(chunk)) = response.chunk().await {
@@ -210,6 +231,15 @@ impl StreamBuffer {
 
                                 notify.notify_waiters();
                             }
+
+                            if total_buffered.saturating_sub(last_progress_report)
+                                >= PROGRESS_REPORT_STEP
+                            {
+                                if let Some(progress) = &progress {
+                                    progress(0, total_buffered as u64, total_size);
+                                }
+                                last_progress_report = total_buffered;
+                            }
                         }
 
                         let (lock, notify) = &*state_clone;
@@ -217,6 +247,16 @@ impl StreamBuffer {
                         state.done = true;
                         state.prebuffer_ready = true;
                         notify.notify_waiters();
+                        drop(state);
+                        if total_buffered > 0
+                            && let Some(progress) = &progress
+                        {
+                            progress(
+                                0,
+                                total_buffered as u64,
+                                total_size.or(Some(total_buffered as u64)),
+                            );
+                        }
                     }
                     Err(e) => {
                         let (lock, notify) = &*state_clone;
@@ -253,11 +293,14 @@ impl StreamBuffer {
         }
     }
 
-    pub fn wait_for_total_size(&self) {
+    /// Wait until the HTTP response headers tell us whether a total size is
+    /// available. A chunked response has no Content-Length, so it must not wait
+    /// for the body to finish downloading.
+    pub fn wait_for_response_headers(&self) {
         let (lock, _notify) = &*self.state;
         loop {
             let state = lock.blocking_lock();
-            if state.total_size.is_some() || state.done {
+            if state.response_ready || state.done {
                 return;
             }
             drop(state);
@@ -268,7 +311,7 @@ impl StreamBuffer {
     pub fn known_total_size(&self) -> Option<u64> {
         let (lock, _) = &*self.state;
         let state = lock.blocking_lock();
-        state.total_size.or(Some(state.buffer.len() as u64))
+        state.total_size
     }
 
     fn wait_for_buffer_ahead(&self, min_ahead: usize) {
@@ -365,5 +408,51 @@ impl Seek for StreamBuffer {
 
         self.pos = new_pos as u64;
         Ok(self.pos)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    #[test]
+    fn missing_length_is_known_once_response_headers_arrive() {
+        let state = Arc::new((
+            Mutex::new(SharedState {
+                buffer: Vec::new(),
+                done: false,
+                error: None,
+                total_size: None,
+                response_ready: false,
+                prebuffer_ready: false,
+            }),
+            Notify::new(),
+        ));
+        let stream = StreamBuffer {
+            state: state.clone(),
+            pos: 0,
+        };
+        let (result_tx, result_rx) = mpsc::channel();
+        let waiter = std::thread::spawn(move || {
+            stream.wait_for_response_headers();
+            result_tx
+                .send(stream.known_total_size())
+                .expect("send header result");
+        });
+
+        {
+            let (lock, notify) = &*state;
+            let mut state = lock.blocking_lock();
+            state.response_ready = true;
+            notify.notify_waiters();
+        }
+
+        let result = result_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("header wait completes without the body finishing");
+        waiter.join().expect("join header waiter");
+
+        assert_eq!(result, None);
     }
 }


### PR DESCRIPTION
Streams remote audio using HTTP ranges with progressive fallback, reducing startup delays. Adds seek aware buffered ranges to player progress bars.

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [ ] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [x] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
