### PR TITLE
feat: sync play queue with subsonic servers

### DIFF
--- a/crates/hooks/src/lib.rs
+++ b/crates/hooks/src/lib.rs
@@ -5,6 +5,7 @@ pub mod artist_images;
 pub mod db_reactivity;
 pub mod debug_db;
 pub mod favorites;
+pub mod play_queue_sync;
 pub mod playback_ref;
 mod player_controller_queue;
 pub mod scrobble_scheduler;

--- a/crates/hooks/src/play_queue_sync.rs
+++ b/crates/hooks/src/play_queue_sync.rs
@@ -1,0 +1,103 @@
+//! Server-side play-queue sync (Subsonic `savePlayQueue`/`getPlayQueue`) —
+//! the remote counterpart to `queue_state`'s local persistence, gated on
+//! `Capabilities::play_queue` so it's a no-op for every other backend.
+
+use crate::use_player_controller::PlayerController;
+use config::MusicService;
+use dioxus::prelude::*;
+use reader::Track;
+
+/// The `c=` client name kopuz sends on every Subsonic call (see
+/// `server::subsonic`'s private `CLIENT_NAME`) — used to tell our own writes
+/// apart from another client's when deciding whether to adopt the server queue.
+const OWN_CLIENT_NAME: &str = "kopuz";
+
+/// The queue's item ids, if every track is this source's own (a Subsonic or
+/// Custom server track) — a mixed or local queue has no single remote queue
+/// to save to.
+fn server_item_ids(queue: &[Track]) -> Option<Vec<String>> {
+    if queue.is_empty() {
+        return None;
+    }
+    queue
+        .iter()
+        .map(|t| match t.id.service() {
+            Some(MusicService::Subsonic) | Some(MusicService::Custom) => {
+                Some(t.id.key().into_owned())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// The `(item_ids, current_id, position_ms)` to save, or `None` if the queue
+/// isn't saveable (see [`server_item_ids`]).
+pub fn save_payload(
+    queue: &[Track],
+    current_queue_index: usize,
+    progress_secs: u64,
+) -> Option<(Vec<String>, Option<String>, u64)> {
+    let item_ids = server_item_ids(queue)?;
+    let current_id = item_ids.get(current_queue_index).cloned();
+    Some((item_ids, current_id, progress_secs * 1000))
+}
+
+/// Push the current queue to the active source. Silently does nothing unless
+/// the source supports it and the whole queue is its own tracks.
+pub fn push(ctrl: PlayerController) {
+    let source = ctrl.active_source.peek().clone();
+    if !source.capabilities().play_queue {
+        return;
+    }
+    let queue = ctrl.queue.peek().clone();
+    let idx = *ctrl.current_queue_index.peek();
+    let progress_secs = *ctrl.current_song_progress.peek();
+    let Some((item_ids, current_id, position_ms)) = save_payload(&queue, idx, progress_secs) else {
+        return;
+    };
+
+    spawn(async move {
+        if let Err(e) = source
+            .save_play_queue(&item_ids, current_id.as_deref(), position_ms)
+            .await
+        {
+            tracing::debug!(error = %e, "play queue push failed");
+        }
+    });
+}
+
+/// Fetch the active source's saved queue and, if the last write came from
+/// another client, adopt it — run once at startup, after the local queue has
+/// already been restored, so a fresher remote state wins over it.
+pub async fn restore_if_changed_elsewhere(mut ctrl: PlayerController) {
+    let source = ctrl.active_source.peek().clone();
+    if !source.capabilities().play_queue {
+        return;
+    }
+    let Ok(Some(remote)) = source.get_play_queue().await else {
+        return;
+    };
+    if remote.tracks.is_empty() {
+        return;
+    }
+    let changed_elsewhere = remote
+        .changed_by
+        .as_deref()
+        .is_some_and(|by| !by.eq_ignore_ascii_case(OWN_CLIENT_NAME));
+    if !changed_elsewhere {
+        return;
+    }
+
+    let current_idx = remote
+        .current_id
+        .as_deref()
+        .and_then(|id| remote.tracks.iter().position(|t| t.id.key() == id))
+        .unwrap_or(0);
+    let progress_secs = remote.position_ms / 1000;
+
+    ctrl.restore_queue_state(remote.tracks, current_idx, progress_secs, Vec::new(), false);
+    crate::toast::toast(&match remote.changed_by {
+        Some(by) => format!("Play queue restored from {by}"),
+        None => "Play queue restored from the server".to_string(),
+    });
+}

--- a/crates/hooks/src/use_player_task.rs
+++ b/crates/hooks/src/use_player_task.rs
@@ -716,6 +716,7 @@ pub fn use_player_task(ctrl: PlayerController) {
         let mut last_progress_report = std::time::Instant::now();
         let mut last_discord_enabled = false;
         let mut last_jellyfin_id: Option<String> = None;
+        let mut last_queue_push_id: Option<String> = None;
         #[cfg(target_os = "macos")]
         let mut last_now_playing_refresh = std::time::Instant::now();
         let mut last_lyrics_prefetch_track: Option<String> = None;
@@ -1027,6 +1028,26 @@ pub fn use_player_task(ctrl: PlayerController) {
                             .instrument(tracing::info_span!("playback.report")),
                         );
                     }
+                }
+
+                // Play-queue sync (Subsonic savePlayQueue): push on track change
+                // and on pause. No-ops via capabilities() for every other backend.
+                {
+                    let current_idx = *ctrl.current_queue_index.read();
+                    let current_item_id = ctrl.get_track_at(current_idx).and_then(|t| {
+                        matches!(
+                            t.id.service(),
+                            Some(MusicService::Subsonic) | Some(MusicService::Custom)
+                        )
+                        .then(|| t.id.key().into_owned())
+                    });
+                    let track_changed = last_queue_push_id != current_item_id;
+                    let just_paused = is_playing != prev_playing && !is_playing;
+
+                    if current_item_id.is_some() && (track_changed || just_paused) {
+                        crate::play_queue_sync::push(ctrl);
+                    }
+                    last_queue_push_id = current_item_id;
                 }
 
                 #[cfg(target_os = "macos")]

--- a/crates/kopuz/src/main.rs
+++ b/crates/kopuz/src/main.rs
@@ -591,6 +591,20 @@ fn App() -> Element {
                     cfg.volume = *volume.peek();
                     cfg
                 });
+                // Same gate as the local flush above, plus the source actually
+                // keeping a server-side queue (Subsonic).
+                let queue_push = (*initial_load_done.peek() && *queue_loaded_ok.peek())
+                    .then(|| active_source.peek().clone())
+                    .filter(|source| source.capabilities().play_queue)
+                    .and_then(|source| {
+                        let state = pending_queue_state_snapshot.peek().clone()?;
+                        let payload = hooks::play_queue_sync::save_payload(
+                            &state.queue,
+                            state.current_queue_index,
+                            state.progress_secs,
+                        )?;
+                        Some((source, payload))
+                    });
                 let _ = std::thread::spawn(move || {
                     let Ok(rt) = tokio::runtime::Builder::new_current_thread()
                         .enable_all()
@@ -606,6 +620,13 @@ fn App() -> Element {
                         }
                         if let Some(cfg) = cfg {
                             let _ = db.save_config(&cfg).await;
+                        }
+                        if let Some((source, (item_ids, current_id, position_ms))) = queue_push
+                            && let Err(e) = source
+                                .save_play_queue(&item_ids, current_id.as_deref(), position_ms)
+                                .await
+                        {
+                            tracing::warn!(error = %e, "play queue flush on close failed");
                         }
                     });
                 })
@@ -1259,6 +1280,13 @@ fn App() -> Element {
                         );
                     }
                 }
+
+                // If the active source keeps its own play queue (Subsonic) and
+                // it was last saved by another client, that's fresher than what
+                // we just restored locally — adopt it.
+                hooks::play_queue_sync::restore_if_changed_elsewhere(ctrl)
+                    .instrument(tracing::info_span!("startup.restore_play_queue"))
+                    .await;
 
                 initial_load_done.set(true);
                 // Kick one reconcile shortly after startup so pending offline

--- a/crates/server/src/source.rs
+++ b/crates/server/src/source.rs
@@ -147,6 +147,25 @@ pub trait MediaSource: Send + Sync {
         Err(SourceError::unsupported("playlist radio"))
     }
 
+    /// Save the play queue to the remote (Subsonic `savePlayQueue`): the full
+    /// item id order, the playing item's id, and its position in milliseconds.
+    /// Only sources whose [`Capabilities::play_queue`] is set override this.
+    async fn save_play_queue(
+        &self,
+        _item_ids: &[String],
+        _current_id: Option<&str>,
+        _position_ms: u64,
+    ) -> Result<(), SourceError> {
+        Err(SourceError::unsupported("play queue sync"))
+    }
+
+    /// Fetch the remote's saved play queue (Subsonic `getPlayQueue`), if it has
+    /// one. Shares [`Capabilities::play_queue`] with
+    /// [`save_play_queue`](Self::save_play_queue).
+    async fn get_play_queue(&self) -> Result<Option<RemotePlayQueue>, SourceError> {
+        Err(SourceError::unsupported("play queue sync"))
+    }
+
     /// The track's canonical public web URL, when this source has shareable web
     /// pages (e.g. a YouTube Music watch link or Spotify track link). `None` otherwise — callers fall
     /// back to a metadata lookup (MusicBrainz). Sync: it's a pure id→URL mapping.

--- a/crates/server/src/source/jellyfin.rs
+++ b/crates/server/src/source/jellyfin.rs
@@ -241,6 +241,7 @@ impl MediaSource for JellyfinSource {
             downloads: true,
             discover: false,
             radio: false,
+            play_queue: false,
             playlists: PlaylistOps::Reorder,
             artist_view: ArtistView::Library,
             albums: AlbumType::Standard,

--- a/crates/server/src/source/local.rs
+++ b/crates/server/src/source/local.rs
@@ -31,6 +31,7 @@ impl MediaSource for LocalSource {
             downloads: false,
             discover: false,
             radio: false,
+            play_queue: false,
             playlists: PlaylistOps::Reorder,
             artist_view: ArtistView::Library,
             albums: AlbumType::Standard,

--- a/crates/server/src/source/offline.rs
+++ b/crates/server/src/source/offline.rs
@@ -31,6 +31,7 @@ impl MediaSource for OfflineServerSource {
             downloads: false,
             discover: false,
             radio: false,
+            play_queue: false,
             playlists: PlaylistOps::None,
             artist_view: ArtistView::Library,
             albums: AlbumType::Standard,

--- a/crates/server/src/source/soundcloud.rs
+++ b/crates/server/src/source/soundcloud.rs
@@ -46,6 +46,7 @@ impl MediaSource for SoundcloudSource {
             downloads: false,
             discover: false,
             radio: false,
+            play_queue: false,
             // No write side wired (api-v2 playlist mutation is DataDome-gated).
             playlists: PlaylistOps::None,
             artist_view: ArtistView::Library,

--- a/crates/server/src/source/spotify.rs
+++ b/crates/server/src/source/spotify.rs
@@ -60,6 +60,7 @@ impl MediaSource for SpotifySource {
             downloads: false,
             discover: true,
             radio: false,
+            play_queue: false,
             playlists: PlaylistOps::None,
             artist_view: ArtistView::Library,
             albums: AlbumType::Standard,

--- a/crates/server/src/source/subsonic.rs
+++ b/crates/server/src/source/subsonic.rs
@@ -6,7 +6,8 @@ use crate::{server_ops::ServerConn, subsonic::SubsonicClient};
 
 use super::{
     AlbumType, ArtistView, AuthOutcome, Capabilities, FavoritesSync, LibrarySnapshot, MediaSource,
-    PlaylistMeta, PlaylistOps, SourceError, StreamInfo, mirror_added, mirror_created,
+    PlaylistMeta, PlaylistOps, RemotePlayQueue, SourceError, StreamInfo, mirror_added,
+    mirror_created,
 };
 
 pub(super) struct SubsonicSource {
@@ -186,6 +187,7 @@ impl MediaSource for SubsonicSource {
             downloads: true,
             discover: false,
             radio: false,
+            play_queue: true,
             playlists: PlaylistOps::Reorder,
             artist_view: ArtistView::Library,
             albums: AlbumType::Standard,
@@ -362,6 +364,75 @@ impl MediaSource for SubsonicSource {
             }
         }
         Ok(out)
+    }
+
+    async fn save_play_queue(
+        &self,
+        item_ids: &[String],
+        current_id: Option<&str>,
+        position_ms: u64,
+    ) -> Result<(), SourceError> {
+        let ids: Vec<&str> = item_ids.iter().map(String::as_str).collect();
+        self.client
+            .save_play_queue(&ids, current_id, Some(position_ms))
+            .await
+            .map_err(SourceError::from)
+    }
+
+    async fn get_play_queue(&self) -> Result<Option<RemotePlayQueue>, SourceError> {
+        let Some(queue) = self.client.get_play_queue().await? else {
+            return Ok(None);
+        };
+        let tracks = queue
+            .entry
+            .into_iter()
+            .map(|item| {
+                // Same mapping as fetch_playlist_entries: the urlhex_ cover tag
+                // the cover resolver expects, album_id carrying it (or :none).
+                let cover_tag = item
+                    .cover_art
+                    .as_ref()
+                    .and_then(|id| self.client.cover_art_url(id, Some(512)).ok())
+                    .map(|url| reader::CoverRef::encode_url(&url));
+                let album_id = reader::CoverRef::stored_item_ref(
+                    self.service,
+                    item.album_id.as_deref().unwrap_or(&item.id),
+                    Some(cover_tag.as_deref().unwrap_or(reader::CoverRef::NO_COVER)),
+                );
+                let artist = item.artist.clone().unwrap_or_default();
+                reader::models::Track {
+                    id: reader::models::TrackId::Server {
+                        service: self.service,
+                        item_id: item.id.clone(),
+                    },
+                    cover: Some(
+                        cover_tag.unwrap_or_else(|| reader::CoverRef::NO_COVER.to_string()),
+                    ),
+                    album_id,
+                    title: item.title,
+                    artist: artist.clone(),
+                    album: item.album.unwrap_or_default(),
+                    duration: item.duration.unwrap_or(0),
+                    khz: item.sampling_rate.unwrap_or(0),
+                    bitrate: item.bit_rate.unwrap_or(0).min(u16::MAX as u32) as u16,
+                    track_number: item.track,
+                    disc_number: item.disc_number,
+                    musicbrainz_release_id: None,
+                    musicbrainz_recording_id: None,
+                    musicbrainz_track_id: None,
+                    playlist_item_id: None,
+                    artists: vec![artist],
+                }
+            })
+            .collect();
+
+        Ok(Some(RemotePlayQueue {
+            tracks,
+            current_id: queue.current,
+            position_ms: queue.position.unwrap_or(0),
+            changed: queue.changed,
+            changed_by: queue.changed_by,
+        }))
     }
 }
 

--- a/crates/server/src/source/types.rs
+++ b/crates/server/src/source/types.rs
@@ -98,6 +98,7 @@ pub struct Capabilities {
     pub downloads: bool,
     pub discover: bool,
     pub radio: bool,
+    pub play_queue: bool,
     pub playlists: PlaylistOps,
     pub artist_view: ArtistView,
     pub albums: AlbumType,
@@ -149,4 +150,17 @@ impl From<crate::ytmusic::discover::YtAlbum> for RemoteAlbum {
             tracks: a.tracks,
         }
     }
+}
+
+/// A server's saved play queue (Subsonic `getPlayQueue`), resolved to tracks.
+pub struct RemotePlayQueue {
+    pub tracks: Vec<reader::Track>,
+    /// The playing track's item id, matched against `tracks[i].id.key()`.
+    pub current_id: Option<String>,
+    pub position_ms: u64,
+    /// When the server last saved this queue (server-clock ISO 8601).
+    pub changed: Option<String>,
+    /// The client name that last saved it — lets a caller tell its own writes
+    /// apart from another client's.
+    pub changed_by: Option<String>,
 }

--- a/crates/server/src/source/youtube_music.rs
+++ b/crates/server/src/source/youtube_music.rs
@@ -66,6 +66,7 @@ impl MediaSource for YtSource {
             downloads: true,
             discover: true,
             radio: true,
+            play_queue: false,
             playlists: PlaylistOps::AddRemove,
             artist_view: ArtistView::Remote,
             albums: AlbumType::YtMusic,

--- a/crates/server/src/subsonic.rs
+++ b/crates/server/src/subsonic.rs
@@ -180,6 +180,24 @@ struct PlaylistCreationData {
     playlist: Option<SubsonicPlaylist>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubsonicPlayQueue {
+    pub current: Option<String>,
+    pub position: Option<u64>,
+    pub changed: Option<String>,
+    pub changed_by: Option<String>,
+    #[serde(default)]
+    pub entry: Vec<SubsonicSong>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GetPlayQueueData {
+    #[serde(default)]
+    play_queue: Option<SubsonicPlayQueue>,
+}
+
 /// Build a Subsonic `getCoverArt` URL without the caller holding a client — the
 /// player's synchronous cover path needs it but must not construct a client.
 pub fn cover_art_url(
@@ -443,6 +461,38 @@ impl SubsonicClient {
         Ok(url.to_string())
     }
 
+    /// The server's saved play queue for this user, if it has one.
+    pub async fn get_play_queue(&self) -> Result<Option<SubsonicPlayQueue>, String> {
+        let data = self
+            .call::<GetPlayQueueData>("getPlayQueue.view", vec![])
+            .await?;
+        Ok(data.play_queue)
+    }
+
+    /// Save the play queue: one `id` param per song, `current` the playing
+    /// song's id, `position` its position in milliseconds. An empty `item_ids`
+    /// with no `current` clears the saved queue.
+    pub async fn save_play_queue(
+        &self,
+        item_ids: &[&str],
+        current_id: Option<&str>,
+        position_ms: Option<u64>,
+    ) -> Result<(), String> {
+        let mut params: Vec<(String, String)> = item_ids
+            .iter()
+            .map(|id| ("id".to_string(), (*id).to_string()))
+            .collect();
+        if let Some(current) = current_id {
+            params.push(("current".to_string(), current.to_string()));
+        }
+        if let Some(position) = position_ms {
+            params.push(("position".to_string(), position.to_string()));
+        }
+        self.call::<EmptyData>("savePlayQueue.view", params)
+            .await
+            .map(|_| ())
+    }
+
     fn auth_params(&self) -> Vec<(String, String)> {
         let salt = self.random_salt();
         let token_input = format!("{}{}", self.password, salt);
@@ -503,5 +553,65 @@ impl SubsonicClient {
         }
 
         Err("Subsonic request failed with unknown error".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Shape verified against a live Navidrome 0.63.2 (OpenSubsonic) instance's
+    // getPlayQueue response, trimmed to the fields this crate reads.
+    #[test]
+    fn play_queue_deserializes_from_a_live_shaped_response() {
+        let envelope: SubsonicEnvelope<GetPlayQueueData> =
+            serde_json::from_value(serde_json::json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "version": "1.16.1",
+                    "playQueue": {
+                        "entry": [
+                            {
+                                "id": "BgdZpTKEu8u6xLGYsZCCXq",
+                                "title": "Expectation",
+                                "album": "Innerspeaker",
+                                "albumId": "7tbDxWiXuAInyHqxBR8ukM",
+                                "artist": "Tame Impala",
+                                "duration": 362,
+                                "bitRate": 901,
+                                "coverArt": "mf-BgdZpTKEu8u6xLGYsZCCXq_6a69cd29"
+                            }
+                        ],
+                        "current": "BgdZpTKEu8u6xLGYsZCCXq",
+                        "position": 45000,
+                        "username": "someone",
+                        "changed": "2026-08-09T18:08:10.49647068Z",
+                        "changedBy": "Arpeggi"
+                    }
+                }
+            }))
+            .expect("valid getPlayQueue response");
+
+        let queue = envelope
+            .response
+            .data
+            .play_queue
+            .expect("playQueue present");
+        assert_eq!(queue.current.as_deref(), Some("BgdZpTKEu8u6xLGYsZCCXq"));
+        assert_eq!(queue.position, Some(45000));
+        assert_eq!(queue.changed_by.as_deref(), Some("Arpeggi"));
+        assert_eq!(queue.entry.len(), 1);
+        assert_eq!(queue.entry[0].title, "Expectation");
+    }
+
+    #[test]
+    fn play_queue_absent_when_nothing_saved() {
+        let envelope: SubsonicEnvelope<GetPlayQueueData> =
+            serde_json::from_value(serde_json::json!({
+                "subsonic-response": { "status": "ok", "version": "1.16.1" }
+            }))
+            .expect("valid empty response");
+
+        assert!(envelope.response.data.play_queue.is_none());
     }
 }


### PR DESCRIPTION
Adds support for Navidrome's queue sync that is also supported by other clients but not Kopuz yet. It's not like spotify sync, it's like I play some music on my phone, I come back to the computer after pausing on my phone, and the same song and queue is ready. Pretty cool ngl :D
AI assistance has been used, and has been tested

<!--
Please include a clear and concise description of the aim of your pull request
above this line.

If this pull request fixes an open issue, link it with `Fixes #<issue number>`.
For playback, scanning, source, packaging, or crash fixes, include the relevant
logs or reproduction steps.
-->

## Sanity Checking

<!--
Please check all that apply. These boxes help maintainers quickly understand
what you already verified and what still needs review.
-->

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [x] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [x] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
