### PR TITLE
fix: flatpak browser filesystem access

### DIFF
--- a/crates/server/src/cookies/browser.rs
+++ b/crates/server/src/cookies/browser.rs
@@ -139,7 +139,7 @@ pub(crate) async fn check_browser_command(arg: String) -> bool {
         .unwrap_or(false)
 }
 
-pub(crate) async fn find_browser_bin(browser: Browser) -> Option<BrowserBin> {
+pub(crate) async fn find_browser_bin(browser: Browser, profile: String) -> Option<BrowserBin> {
     let env_key = format!(
         "KOPUZ_{}_BIN",
         browser.id().to_uppercase().replace('-', "_")
@@ -180,7 +180,9 @@ pub(crate) async fn find_browser_bin(browser: Browser) -> Option<BrowserBin> {
 
     for cand in browser_flatpak_ids(browser) {
         if check_browser_command(format!("flatpak info {cand}")).await {
-            return Some(BrowserBin::CommandLine(format!("flatpak run {cand}")));
+            return Some(BrowserBin::CommandLine(format!(
+                "flatpak run --filesystem={profile} {cand}"
+            )));
         }
     }
 

--- a/crates/server/src/cookies/browser.rs
+++ b/crates/server/src/cookies/browser.rs
@@ -174,7 +174,9 @@ pub(crate) async fn find_browser_bin(browser: Browser, profile: String) -> Optio
     {
         let id = v.to_string().to_owned();
         if check_browser_command(format!("flatpak info {id}")).await {
-            return Some(BrowserBin::CommandLine(format!("flatpak run {id}")));
+            return Some(BrowserBin::CommandLine(format!(
+                "flatpak run --filesystem={profile} {id}"
+            )));
         }
     }
 

--- a/crates/server/src/cookies/signin.rs
+++ b/crates/server/src/cookies/signin.rs
@@ -63,7 +63,9 @@ where
                 browser.id().to_uppercase().replace('-', "_")
             )
         };
-        find_browser_bin(browser).await.ok_or(error)?
+        find_browser_bin(browser, profile.display().to_string())
+            .await
+            .ok_or(error)?
     };
     tracing::info!(%bin, profile = %profile.display(), "launching sign-in browser");
     let mut cmd = browser_command(&bin);


### PR DESCRIPTION
<!--
Please include a clear and concise description of the aim of your pull request
above this line.

If this pull request fixes an open issue, link it with `Fixes #<issue number>`.
For playback, scanning, source, packaging, or crash fixes, include the relevant
logs or reproduction steps.
-->

If running a flatpak browser add override for path incase it doesnt have access to kopuz's config 

## Sanity Checking

<!--
Please check all that apply. These boxes help maintainers quickly understand
what you already verified and what still needs review.
-->

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [x] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
