### PR TITLE
components: keep transport controls and sliders LTR in RTL locales

### DIFF
--- a/crates/components/src/common/controls/dots_menu.rs
+++ b/crates/components/src/common/controls/dots_menu.rs
@@ -39,10 +39,16 @@ pub struct DotsMenuProps {
     pub icon: String,
 }
 
+/// The panel measures itself pinned to the viewport origin, because `left`/`right`
+/// left to `auto` shrink-to-fit against whatever room sits beside the trigger's
+/// static position — in RTL that is a few pixels, which collapses the panel to
+/// icon width. `anchor` is likewise phrased in LTR terms and mirrored for RTL so
+/// the panel opens towards the middle of the window instead of off-screen.
 #[component]
 pub fn DotsMenu(props: DotsMenuProps) -> Element {
     let mut trigger_element = use_signal(|| None::<MountedEvent>);
     let mut panel_geometry = use_signal(|| None::<(f64, f64, f64, f64)>);
+    let is_rtl = i18n::is_rtl();
 
     let base_button_class = format!(
         "w-8 h-8 flex items-center justify-center rounded-full hover:bg-white/10 text-slate-400 hover:text-white transition-colors {}",
@@ -52,7 +58,7 @@ pub fn DotsMenu(props: DotsMenuProps) -> Element {
         Some((left, top, width, height)) => format!(
             "position: fixed; left: clamp(8px, {left}px, calc(100vw - {width}px - 8px)); top: clamp(8px, {top}px, calc(100vh - {height}px - 8px)); visibility: visible;"
         ),
-        None => "position: fixed; visibility: hidden;".to_string(),
+        None => "position: fixed; left: 0; top: 0; visibility: hidden;".to_string(),
     };
 
     rsx! {
@@ -85,7 +91,7 @@ pub fn DotsMenu(props: DotsMenuProps) -> Element {
                 }
 
                 div {
-                    class: "w-auto bg-neutral-900 border border-white/10 rounded-lg dots-menu-panel py-1 shadow-xl",
+                    class: "w-auto flex flex-col bg-neutral-900 border border-white/10 rounded-lg dots-menu-panel py-1 shadow-xl",
                     style: "{panel_style}",
                     onmounted: {
                         let anchor = props.anchor.clone();
@@ -104,7 +110,7 @@ pub fn DotsMenu(props: DotsMenuProps) -> Element {
                                 let Ok(panel_rect) = panel_evt.get_client_rect().await else {
                                     return;
                                 };
-                                let left = if anchor == "left" {
+                                let left = if (anchor == "left") != is_rtl {
                                     trigger_rect.min_x()
                                 } else {
                                     trigger_rect.max_x() - panel_rect.width()
@@ -138,7 +144,7 @@ pub fn DotsMenu(props: DotsMenuProps) -> Element {
                             rsx! {
                                 button {
                                     key: "{idx}",
-                                    class: "w-full text-left px-4 py-2 text-sm {text_color} hover:bg-white/10 flex items-center gap-2 transition-colors whitespace-nowrap",
+                                    class: "px-4 py-2 text-sm {text_color} hover:bg-white/10 flex items-center gap-2 transition-colors whitespace-nowrap",
                                     onclick: move |_| {
                                         panel_geometry.set(None);
                                         props.on_action.call(idx);

--- a/crates/components/src/layout/normal/bottombar.rs
+++ b/crates/components/src/layout/normal/bottombar.rs
@@ -66,7 +66,7 @@ pub fn BottombarNormal(
                     span { class: "text-[13px] font-bold text-white truncate leading-tight", "{current_song_title}" }
                     span { class: "text-[11px] font-medium text-white/60 truncate leading-tight", "{current_song_artist}" }
                 }
-                div { class: "flex items-center gap-1 pr-1",
+                div { class: "flex items-center gap-1 pr-1", dir: "ltr",
                     button {
                         class: "w-12 h-12 flex items-center justify-center text-white text-xl active:scale-90 transition-transform",
                         onclick: move |evt| { evt.stop_propagation(); ctrl.toggle(); },

--- a/crates/components/src/layout/vaxry/bottombar.rs
+++ b/crates/components/src/layout/vaxry/bottombar.rs
@@ -66,7 +66,7 @@ pub fn BottombarVaxry(
                     span { class: "text-[13px] font-semibold text-white/90 truncate leading-tight", "{current_song_title}" }
                     span { class: "text-[11px] text-slate-400 truncate leading-tight", "{current_song_artist}" }
                 }
-                div { class: "flex items-center gap-0.5 pr-1",
+                div { class: "flex items-center gap-0.5 pr-1", dir: "ltr",
                     button {
                         class: if fav { "w-10 h-10 flex items-center justify-center text-red-400 active:scale-90 transition-transform" } else { "w-10 h-10 flex items-center justify-center text-slate-400 active:scale-90 transition-transform" },
                         onclick: move |evt| { evt.stop_propagation(); toggle_favorite(ctrl.current_track_snapshot.read().clone()); },
@@ -147,7 +147,7 @@ pub fn BottombarVaxry(
                     div {
                         class: "flex items-baseline gap-1.5 min-w-0",
                         span {
-                            class: "text-xs font-semibold text-white/90 truncate hover:underline cursor-pointer shrink-0 max-w-[40%]",
+                            class: "text-xs font-semibold text-white/90 truncate hover:underline cursor-pointer min-w-0",
                             onclick: move |_| {
                                 let album_id = current_track_snapshot
                                     .as_ref()
@@ -159,7 +159,7 @@ pub fn BottombarVaxry(
                         }
                         span { class: "text-white/20 text-[10px] shrink-0", "—" }
                         span {
-                            class: "text-[11px] text-slate-400 truncate min-w-0 cursor-pointer hover:underline hover:text-slate-300",
+                            class: "text-[11px] text-slate-400 truncate min-w-0 shrink-0 max-w-[40%] cursor-pointer hover:underline hover:text-slate-300",
                             onclick: move |_| {
                                 let artist = current_song_artist.read().clone();
                                 nav_ctrl.navigate_to_artist(artist);

--- a/crates/components/src/playback/compact.rs
+++ b/crates/components/src/playback/compact.rs
@@ -122,7 +122,7 @@ pub fn CompactPlayer() -> Element {
                     class: "flex-1 min-w-0 flex flex-col justify-center gap-0.5",
                     span { class: skin.title, "{ctrl.current_song_title}" }
                     span { class: "text-[11px] text-white/55 truncate leading-tight", "{ctrl.current_song_artist}" }
-                    span { class: "text-[9px] text-white/35 font-mono leading-tight",
+                    span { class: "text-[9px] text-white/35 font-mono leading-tight", dir: "ltr",
                         if is_radio { "LIVE" } else { "{fmt_time(display_progress)} / {fmt_time(duration)}" }
                     }
                 }
@@ -138,6 +138,7 @@ pub fn CompactPlayer() -> Element {
 
             div {
                 class: "relative z-10 shrink-0 flex items-center justify-center gap-2 px-3 pb-2",
+                dir: "ltr",
                 onmousedown: move |evt| evt.stop_propagation(),
                 button {
                     class: skin.ctrl_btn,
@@ -158,6 +159,7 @@ pub fn CompactPlayer() -> Element {
 
             div {
                 class: format!("relative z-10 h-[3px] w-full bg-white/10 shrink-0 overflow-hidden {}", if is_radio || is_loading { "" } else { "group cursor-pointer" }),
+                dir: "ltr",
                 onmousedown: move |evt| evt.stop_propagation(),
                 PlaybackBufferIndicator {
                     ranges: buffered_ranges,

--- a/crates/components/src/playback/controls.rs
+++ b/crates/components/src/playback/controls.rs
@@ -250,6 +250,11 @@ fn transport_classes(variant: ControlsVariant) -> TransportClasses {
     }
 }
 
+/// Transport and both sliders force `dir="ltr"`. Time runs left-to-right in
+/// every locale, and the native `input[type=range]` flips its value mapping
+/// under RTL while the fills below it are drawn from the physical left — so
+/// inheriting the app direction would make the sliders track the pointer
+/// backwards and put elapsed time on the wrong end.
 #[component]
 pub fn TransportButtons(is_playing: Signal<bool>, variant: ControlsVariant) -> Element {
     let mut ctrl = use_context::<PlayerController>();
@@ -262,6 +267,7 @@ pub fn TransportButtons(is_playing: Signal<bool>, variant: ControlsVariant) -> E
     rsx! {
         div {
             class: classes.wrapper,
+            dir: "ltr",
             style: if variant == ControlsVariant::Fullscreen { "max-width: 640px;" } else { "" },
             button {
                 class: classes.side,
@@ -330,6 +336,7 @@ pub fn SeekSlider(
         ControlsVariant::Fullscreen => rsx! {
             div {
                 class: "w-full mb-3",
+                dir: "ltr",
                 style: "max-width: 640px;",
                 div {
                     class: "flex items-center gap-3",
@@ -382,6 +389,7 @@ pub fn SeekSlider(
         ControlsVariant::Bar => rsx! {
             div {
                 class: "flex items-center gap-2 w-full",
+                dir: "ltr",
                 span { class: "text-[10px] text-slate-500 w-8 text-right font-mono", "{fmt_time(display_progress)}" }
                 div {
                     class: format!("flex-1 h-1 bg-white/10 rounded-full relative {}", if can_seek { "group cursor-pointer" } else { "" }),
@@ -432,6 +440,7 @@ pub fn VolumeSlider(
         ControlsVariant::Fullscreen => rsx! {
             div {
                 class: "flex items-center gap-5 w-full",
+                dir: "ltr",
                 style: "max-width: 640px;",
                 i { class: "fa-solid fa-volume-low text-white/40" }
                 div {
@@ -470,6 +479,7 @@ pub fn VolumeSlider(
         ControlsVariant::Bar => rsx! {
             div {
                 class: "flex items-center gap-2 group",
+                dir: "ltr",
                 button {
                     class: "w-9 h-9 rounded-full flex items-center justify-center text-slate-400 hover:text-white hover:bg-white/10 transition-colors active:scale-95",
                     onclick: move |_| toggle_mute.call(()),

--- a/crates/kopuz/assets/themes.css
+++ b/crates/kopuz/assets/themes.css
@@ -909,6 +909,55 @@ select:disabled {
     }
 }
 
+/* The fan disc is built around a hub on its left edge; RTL puts the column on
+   the other side of the workspace, so mirror the geometry to keep the hub
+   against the window edge and the wedges fanning into the content. */
+@media (min-width: 901px) and (min-height: 541px) {
+    [dir="rtl"] .settings-page.settings-layout-cd {
+        padding-right: 0 !important;
+        padding-left: 1.5rem !important;
+    }
+
+    [dir="rtl"] .settings-page.settings-layout-cd > h1 {
+        margin-right: 1.5rem;
+        margin-left: 0;
+    }
+
+    [dir="rtl"] .settings-layout-cd .settings-fan-disc::before {
+        border-right: 0;
+        border-left: 1px solid color-mix(in srgb, var(--color-white, #ffffff) 13%, transparent);
+        border-radius: 999px 0 0 999px;
+        background:
+            repeating-radial-gradient(
+                circle at right center,
+                transparent 0 8px,
+                color-mix(in srgb, var(--color-white, #ffffff) 3.5%, transparent) 9px,
+                transparent 10px
+            ),
+            radial-gradient(
+                circle at right center,
+                color-mix(in srgb, var(--color-white, #ffffff) 8%, var(--color-black, #000000)) 0 21%,
+                color-mix(in srgb, var(--color-black, #000000) 72%, transparent) 21.5% 100%
+            );
+    }
+
+    [dir="rtl"] .settings-layout-cd .settings-fan-disc::after {
+        right: -12.9%;
+        left: auto;
+    }
+
+    [dir="rtl"] .settings-layout-cd .settings-fan-item {
+        left: 0;
+        clip-path: polygon(50% 50%, 0.96% 40.25%, 0% 50%, 0.96% 59.75%);
+        transform: rotate(calc(-1 * var(--fan-angle)));
+    }
+
+    [dir="rtl"] .settings-layout-cd .settings-fan-label {
+        left: calc(100% - var(--label-x));
+        transform: translate(-50%, -50%) rotate(calc(-1 * var(--label-tilt)));
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .settings-fan-item,
     .settings-fan-label {


### PR DESCRIPTION
Issues related to RTL fixed.
https://github.com/Kopuz-org/kopuz/issues/549
https://github.com/Kopuz-org/kopuz/issues/536
https://github.com/Kopuz-org/kopuz/issues/534

plus CD view fixed for RTL

all css stuff so thanks opus for not getting me into frontend stuff

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [ ] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [x] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
