### PR TITLE
components: Preserve playlist folder mutations until completion

### DIFF
--- a/crates/components/src/playlist/folder_picker.rs
+++ b/crates/components/src/playlist/folder_picker.rs
@@ -1,11 +1,34 @@
 use dioxus::prelude::*;
 use hooks::db_reactivity::Table;
 use hooks::use_db_queries::use_playlists;
+use std::future::Future;
+
+async fn run_folder_mutation<F, E, S, C>(mutation: F, on_success: S, on_close: C)
+where
+    F: Future<Output = Result<(), E>>,
+    S: FnOnce(),
+    C: FnOnce(),
+{
+    if mutation.await.is_ok() {
+        on_success();
+    }
+    on_close();
+}
+
+async fn create_and_move_folder<C, M, E>(create: C, move_playlist: M) -> Result<(), E>
+where
+    C: Future<Output = Result<(), E>>,
+    M: Future<Output = Result<(), E>>,
+{
+    create.await?;
+    move_playlist.await
+}
 
 #[component]
 pub fn FolderPickerModal(playlist_id: String, on_close: EventHandler<()>) -> Element {
     let mut new_folder_name = use_signal(String::new);
     let mut show_create = use_signal(|| false);
+    let mut is_submitting = use_signal(|| false);
     let gens = hooks::db_reactivity::use_generations();
     let playlists_res = use_playlists();
 
@@ -22,7 +45,11 @@ pub fn FolderPickerModal(playlist_id: String, on_close: EventHandler<()>) -> Ele
     rsx! {
         div {
             class: "fixed inset-0 z-50 flex items-center justify-center bg-black/60",
-            onclick: move |_| on_close.call(()),
+            onclick: move |_| {
+                if !*is_submitting.peek() {
+                    on_close.call(());
+                }
+            },
 
             div {
                 class: "bg-neutral-900 border border-white/10 rounded-lg p-6 w-80 shadow-2xl",
@@ -42,21 +69,24 @@ pub fn FolderPickerModal(playlist_id: String, on_close: EventHandler<()>) -> Ele
                                 rsx! {
                                     button {
                                         key: "{fid}",
+                                        disabled: *is_submitting.read(),
                                         class: "w-full text-left px-3 py-2 rounded-lg text-sm text-white hover:bg-white/10 flex items-center gap-2 transition-colors",
                                         onclick: move |_| {
+                                            if *is_submitting.peek() {
+                                                return;
+                                            }
+                                            is_submitting.set(true);
                                             let local = consume_context::<Signal<::server::source::ActiveSource>>().peek().clone();
                                             let pid = pid2.clone();
                                             let fid = fid.clone();
                                             spawn(async move {
-                                                if local
-                                                    .set_playlist_folder(&pid, Some(&fid))
-                                                    .await
-                                                    .is_ok()
-                                                {
-                                                    gens.bump(Table::Folders);
-                                                }
+                                                run_folder_mutation(
+                                                    local.set_playlist_folder(&pid, Some(&fid)),
+                                                    move || gens.bump(Table::Folders),
+                                                    move || on_close.call(()),
+                                                )
+                                                .await;
                                             });
-                                            on_close.call(());
                                         },
                                         i { class: "fa-solid fa-folder text-amber-400 text-xs" }
                                         "{fname}"
@@ -72,51 +102,67 @@ pub fn FolderPickerModal(playlist_id: String, on_close: EventHandler<()>) -> Ele
                         input {
                             class: "flex-1 bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-slate-500 focus:outline-none focus:border-indigo-500",
                             placeholder: i18n::t("folder_name"),
+                            disabled: *is_submitting.read(),
                             value: "{new_folder_name}",
                             oninput: move |evt| new_folder_name.set(evt.value()),
                             onkeydown: move |evt| {
                                 if evt.key() == Key::Enter {
                                     let name = new_folder_name.read().trim().to_string();
-                                    if !name.is_empty() {
+                                    if !name.is_empty() && !*is_submitting.peek() {
+                                        is_submitting.set(true);
                                         let new_id = uuid::Uuid::new_v4().to_string();
                                         let pid = pid_keydown.clone();
                                         let source = consume_context::<Signal<::server::source::ActiveSource>>().peek().clone();
                                         spawn(async move {
-                                            if source.create_folder(&new_id, &name).await.is_ok()
-                                                && source
-                                                    .set_playlist_folder(&pid, Some(&new_id))
+                                            run_folder_mutation(
+                                                async move {
+                                                    create_and_move_folder(
+                                                        source.create_folder(&new_id, &name),
+                                                        source.set_playlist_folder(
+                                                            &pid,
+                                                            Some(&new_id),
+                                                        ),
+                                                    )
                                                     .await
-                                                    .is_ok()
-                                            {
-                                                gens.bump(Table::Folders);
-                                            }
+                                                },
+                                                move || gens.bump(Table::Folders),
+                                                move || on_close.call(()),
+                                            )
+                                            .await;
                                         });
-                                        on_close.call(());
                                     }
                                 }
                             },
                         }
                         button {
+                            disabled: *is_submitting.read(),
                             class: "px-3 py-2 bg-indigo-500 hover:bg-indigo-400 text-white rounded-lg text-sm transition-colors",
                             onclick: {
                                 let pid4 = pid_btn.clone();
                                 move |_| {
                                     let name = new_folder_name.read().trim().to_string();
-                                    if !name.is_empty() {
+                                    if !name.is_empty() && !*is_submitting.peek() {
+                                        is_submitting.set(true);
                                         let new_id = uuid::Uuid::new_v4().to_string();
                                         let pid = pid4.clone();
                                         let source = consume_context::<Signal<::server::source::ActiveSource>>().peek().clone();
                                         spawn(async move {
-                                            if source.create_folder(&new_id, &name).await.is_ok()
-                                                && source
-                                                    .set_playlist_folder(&pid, Some(&new_id))
+                                            run_folder_mutation(
+                                                async move {
+                                                    create_and_move_folder(
+                                                        source.create_folder(&new_id, &name),
+                                                        source.set_playlist_folder(
+                                                            &pid,
+                                                            Some(&new_id),
+                                                        ),
+                                                    )
                                                     .await
-                                                    .is_ok()
-                                            {
-                                                gens.bump(Table::Folders);
-                                            }
+                                                },
+                                                move || gens.bump(Table::Folders),
+                                                move || on_close.call(()),
+                                            )
+                                            .await;
                                         });
-                                        on_close.call(());
                                     }
                                 }
                             },
@@ -127,6 +173,7 @@ pub fn FolderPickerModal(playlist_id: String, on_close: EventHandler<()>) -> Ele
 
                 div { class: "flex gap-2",
                     button {
+                        disabled: *is_submitting.read(),
                         class: "flex-1 py-2 text-sm text-slate-400 hover:text-white border border-white/10 rounded-lg transition-colors",
                         onclick: move |_| {
                             let next = !*show_create.read();
@@ -137,12 +184,177 @@ pub fn FolderPickerModal(playlist_id: String, on_close: EventHandler<()>) -> Ele
                         "{i18n::t(\"new_folder\")}"
                     }
                     button {
+                        disabled: *is_submitting.read(),
                         class: "px-4 py-2 text-sm text-slate-400 hover:text-white transition-colors",
-                        onclick: move |_| on_close.call(()),
+                        onclick: move |_| {
+                            if !*is_submitting.peek() {
+                                on_close.call(());
+                            }
+                        },
                         "{i18n::t(\"cancel\")}"
                     }
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{create_and_move_folder, run_folder_mutation};
+    use std::sync::{Arc, Mutex};
+
+    fn record(events: &Arc<Mutex<Vec<&'static str>>>, event: &'static str) {
+        events.lock().expect("event log poisoned").push(event);
+    }
+
+    #[tokio::test]
+    async fn selecting_folder_finishes_mutation_before_refresh_and_close() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let (complete, pending) = tokio::sync::oneshot::channel();
+        let mutation_events = events.clone();
+        let refresh_events = events.clone();
+        let close_events = events.clone();
+
+        let task = tokio::spawn(run_folder_mutation(
+            async move {
+                record(&mutation_events, "mutation-started");
+                pending.await.map_err(|_| ())?;
+                record(&mutation_events, "mutation-finished");
+                Ok::<(), ()>(())
+            },
+            move || record(&refresh_events, "refreshed"),
+            move || record(&close_events, "closed"),
+        ));
+
+        tokio::task::yield_now().await;
+        assert_eq!(
+            *events.lock().expect("event log poisoned"),
+            ["mutation-started"]
+        );
+        complete.send(()).expect("mutation receiver dropped");
+        task.await.expect("mutation task panicked");
+        assert_eq!(
+            *events.lock().expect("event log poisoned"),
+            [
+                "mutation-started",
+                "mutation-finished",
+                "refreshed",
+                "closed"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn creating_folder_finishes_both_mutations_before_refresh_and_close() {
+        for action in ["enter", "button"] {
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let mutation_events = events.clone();
+            let refresh_events = events.clone();
+            let close_events = events.clone();
+
+            run_folder_mutation(
+                create_and_move_folder(
+                    {
+                        let events = mutation_events.clone();
+                        async move {
+                            record(&events, "folder-created");
+                            Ok::<(), ()>(())
+                        }
+                    },
+                    async move {
+                        record(&mutation_events, "playlist-moved");
+                        Ok::<(), ()>(())
+                    },
+                ),
+                move || record(&refresh_events, "refreshed"),
+                move || record(&close_events, "closed"),
+            )
+            .await;
+
+            assert_eq!(
+                *events.lock().expect("event log poisoned"),
+                ["folder-created", "playlist-moved", "refreshed", "closed"],
+                "unexpected lifecycle for {action} action"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_mutation_skips_refresh_but_still_closes_after_attempt() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mutation_events = events.clone();
+        let refresh_events = events.clone();
+        let close_events = events.clone();
+
+        run_folder_mutation(
+            async move {
+                record(&mutation_events, "mutation-failed");
+                Err::<(), ()>(())
+            },
+            move || record(&refresh_events, "refreshed"),
+            move || record(&close_events, "closed"),
+        )
+        .await;
+
+        assert_eq!(
+            *events.lock().expect("event log poisoned"),
+            ["mutation-failed", "closed"]
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_folder_creation_does_not_attempt_playlist_move() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let create_events = events.clone();
+        let move_events = events.clone();
+
+        let result = create_and_move_folder(
+            async move {
+                record(&create_events, "folder-create-failed");
+                Err::<(), ()>(())
+            },
+            async move {
+                record(&move_events, "playlist-moved");
+                Ok::<(), ()>(())
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            *events.lock().expect("event log poisoned"),
+            ["folder-create-failed"]
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_playlist_move_skips_refresh_but_still_closes() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let create_events = events.clone();
+        let move_events = events.clone();
+        let refresh_events = events.clone();
+        let close_events = events.clone();
+
+        run_folder_mutation(
+            create_and_move_folder(
+                async move {
+                    record(&create_events, "folder-created");
+                    Ok::<(), ()>(())
+                },
+                async move {
+                    record(&move_events, "playlist-move-failed");
+                    Err::<(), ()>(())
+                },
+            ),
+            move || record(&refresh_events, "refreshed"),
+            move || record(&close_events, "closed"),
+        )
+        .await;
+
+        assert_eq!(
+            *events.lock().expect("event log poisoned"),
+            ["folder-created", "playlist-move-failed", "closed"]
+        );
     }
 }


### PR DESCRIPTION
## Sanity Checking

<!--
Please check all that apply. These boxes help maintainers quickly understand
what you already verified and what still needs review.
-->

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [ ] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [ ] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [ ] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.
- [ ] `x86_64-linux`
  Not verified: this needs a person on the named hardware or environment.
- [x] `aarch64-linux`
- [ ] `x86_64-darwin`
  Not verified: this needs a person on the named hardware or environment.
- [x] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
- Select an existing folder for an unfiled playlist; verify `set_playlist_folder` completes with the selected folder id, the folder generation is bumped, and only then the modal closes. - Create a non-empty folder with the Enter key and with the Create button; verify each path completes `create_folder` followed by `set_playlist_folder` before closing and refreshes the folder view on success. - Force a folder mutation failure; verify the task is still polled to completion, no folder generation bump occurs, and the modal retains the existing close-after-attempt behavior.

Fixes #582

AI was used for assistance.
