### PR TITLE
feat: force password store and login url

### DIFF
--- a/crates/server/src/applemusic/signin.rs
+++ b/crates/server/src/applemusic/signin.rs
@@ -79,6 +79,7 @@ pub async fn launch_signin_and_extract(
     let mut cmd = ip::browser_command(&bin);
     cmd.arg("--no-first-run")
         .arg("--no-default-browser-check")
+        .arg("--password-store=basic")
         .arg(format!("--user-data-dir={}", profile.display()));
     #[cfg(target_os = "windows")]
     {
@@ -86,7 +87,7 @@ pub async fn launch_signin_and_extract(
         cmd.creation_flags(0x0100_0000);
     }
     let mut child = cmd
-        .arg(SIGNIN_URL)
+        .arg(format!("--app={SIGNIN_URL}"))
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .kill_on_drop(true)

--- a/crates/server/src/cookies/signin.rs
+++ b/crates/server/src/cookies/signin.rs
@@ -71,6 +71,7 @@ where
     let mut cmd = browser_command(&bin);
     cmd.arg("--no-first-run")
         .arg("--no-default-browser-check")
+        .arg("--password-store=basic")
         .arg(format!("--user-data-dir={}", profile.display()));
     // Windows: kopuz's WebView2 UI runs us inside a job object whose sandbox
     // quota (1 active process) stops a spawned Chrome from creating the nested
@@ -82,7 +83,7 @@ where
         cmd.creation_flags(0x0100_0000);
     }
     let mut child = cmd
-        .arg(signin_url)
+        .arg(format!("--app={signin_url}"))
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .kill_on_drop(true)


### PR DESCRIPTION
<!--
Please include a clear and concise description of the aim of your pull request
above this line.

If this pull request fixes an open issue, link it with `Fixes #<issue number>`.
For playback, scanning, source, packaging, or crash fixes, include the relevant
logs or reproduction steps.
-->

- Force `--password-store=basic` since kopuz have issues with reading from others. 
Closes https://github.com/Kopuz-org/kopuz/issues/644

- Added `--app=` to open the url like PWA instead in browser. (Works on browsers which force OOBE like vivaldi)
<img width="880" height="660" alt="image" src="https://github.com/user-attachments/assets/013fe91b-77a7-4251-853e-cea0ea6a930e" />

## Sanity Checking

<!--
Please check all that apply. These boxes help maintainers quickly understand
what you already verified and what still needs review.
-->

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [x] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
