### PR TITLE
server: fall back to legacy subsonic auth when tokens are rejected

### DIFF
--- a/crates/hooks/src/playback_ref.rs
+++ b/crates/hooks/src/playback_ref.rs
@@ -21,6 +21,11 @@ impl<'a> PlaybackItemRef<'a> {
                 station_id: parts.next().unwrap_or_default(),
                 stream_id: parts.next().unwrap_or_default(),
             },
+            "nextcloud" => Self::Server {
+                service: scheme,
+                item_id: value.get(scheme.len() + 1..).unwrap_or_default(),
+                extra: None,
+            },
             "jellyfin" | "subsonic" | "custom" | "ytmusic" | "soundcloud" | "applemusic"
             | "spotify" => Self::Server {
                 service: scheme,
@@ -119,6 +124,19 @@ mod tests {
                 extra: Some("extra"),
             }
         );
+    }
+
+    #[test]
+    fn parses_nextcloud_refs_whole() {
+        assert_eq!(
+            PlaybackItemRef::parse("nextcloud:/music/Artist/Vol 1: Deluxe/01.mp3"),
+            PlaybackItemRef::Server {
+                service: "nextcloud",
+                item_id: "/music/Artist/Vol 1: Deluxe/01.mp3",
+                extra: None,
+            }
+        );
+        assert!(PlaybackItemRef::parse("nextcloud:/music/a.mp3").is_server());
     }
 
     #[test]

--- a/crates/kopuz/src/main.rs
+++ b/crates/kopuz/src/main.rs
@@ -1356,9 +1356,19 @@ fn App() -> Element {
                     i18n::set_locale(&loaded.language);
                 }
 
-                // Local is the source of truth: no auto-switch to a server on
-                // startup. An unselected source stays Local (the config default);
-                // the user picks a server explicitly via the sidebar.
+                // No auto-switch on startup; an unselected source stays Local.
+                // A restored server still needs `config.server` rehydrated: creds
+                // live in the servers table, not the blob, and the player reads
+                // them to resolve a track.
+                let restored_source = config.peek().active_source.clone();
+                if restored_source.server_id().is_some() {
+                    hooks::source_switch::apply_source_switch(
+                        config,
+                        db.reads(),
+                        restored_source,
+                    )
+                    .await;
+                }
 
                 let queue_state = utils::offload(async move {
                     queue_loaded.and_then(|snap| {

--- a/crates/pages/src/album.rs
+++ b/crates/pages/src/album.rs
@@ -77,9 +77,7 @@ pub fn Album(
         if let Some(albums) = albums_res.read().clone() {
             has_fetched.set(true);
             if albums.is_empty() {
-                spawn(async move {
-                    let _ = crate::server::subsonic_sync::sync_server_library(false).await;
-                });
+                crate::server::subsonic_sync::spawn_library_sync(false);
             }
         }
     });

--- a/crates/pages/src/home_body.rs
+++ b/crates/pages/src/home_body.rs
@@ -100,9 +100,7 @@ pub fn HomeBody(
     // Servers fill an empty cache by syncing; local is populated by the scan.
     let mut fetch_remote = move || {
         has_fetched.set(true);
-        spawn(async move {
-            let _ = crate::server::subsonic_sync::sync_server_library(false).await;
-        });
+        crate::server::subsonic_sync::spawn_library_sync(false);
     };
 
     use_effect(move || {

--- a/crates/pages/src/library.rs
+++ b/crates/pages/src/library.rs
@@ -95,22 +95,10 @@ pub fn LibraryPage(
     });
 
     // Remote sync (servers). Local never calls this — its refresh is `on_rescan`.
-    let mut is_loading = use_signal(|| false);
     let mut has_fetched = use_signal(|| false);
-    let mut fetch_generation = use_signal(|| 0usize);
     let mut sync_server = move || {
         has_fetched.set(true);
-        is_loading.set(true);
-        fetch_generation.with_mut(|g| *g += 1);
-        let current_gen = *fetch_generation.peek();
-        spawn(async move {
-            if *fetch_generation.read() == current_gen {
-                let _ = crate::server::subsonic_sync::sync_server_library(true).await;
-                if *fetch_generation.read() == current_gen {
-                    is_loading.set(false);
-                }
-            }
-        });
+        crate::server::subsonic_sync::spawn_library_sync(true);
     };
     // First visit with an empty server library → auto-pull once.
     use_effect(move || {
@@ -572,7 +560,7 @@ pub fn LibraryPage(
                     scroll_positions.write().insert(Route::Library, scroll);
                 },
                 if is_empty {
-                    if window.total.read().is_none() || *is_loading.read() {
+                    if window.total.read().is_none() || crate::server::subsonic_sync::SYNC_RUNNING() {
                         div { class: "flex items-center justify-center py-12",
                             i { class: "fa-solid fa-spinner fa-spin text-3xl text-white/20" }
                         }
@@ -581,7 +569,7 @@ pub fn LibraryPage(
                     }
                 } else {
                     {tracks_nodes.into_iter()}
-                    if *is_loading.read() {
+                    if crate::server::subsonic_sync::SYNC_RUNNING() {
                         div { class: "flex items-center justify-center py-4",
                             i { class: "fa-solid fa-spinner fa-spin text-xl text-white/20" }
                         }

--- a/crates/pages/src/server/subsonic_sync.rs
+++ b/crates/pages/src/server/subsonic_sync.rs
@@ -1,7 +1,39 @@
+use dioxus::core::spawn_forever;
 use dioxus::prelude::*;
 use hooks::db_reactivity::Table;
 use reader::models::Album;
-use tracing::info;
+use tracing::{error, info};
+
+/// Whether a sync is in flight, for the spinner and the guard below. Global
+/// because the task outlives the page that started it.
+pub static SYNC_RUNNING: GlobalSignal<bool> = Signal::global(|| false);
+
+/// Start a library sync detached from the calling page, one at a time.
+///
+/// `spawn_forever` because a scope-tied task dies with its component, and a
+/// source slow enough to outlast a page change (Nextcloud probes every file
+/// header) never survived to persist anything: the same trap as the downloads
+/// in #327. The guard collapses the stampede an empty library provokes, since
+/// Home, Library and Album each pull on mount.
+pub fn spawn_library_sync(clear_first: bool) {
+    if *SYNC_RUNNING.peek() {
+        return;
+    }
+    // A detached task has no scope, so the contexts are read here, not inside it.
+    let read_db = consume_context::<hooks::ReadDb>();
+    let gens = consume_context::<hooks::db_reactivity::Generations>();
+    let source = consume_context::<Signal<::server::source::ActiveSource>>()
+        .peek()
+        .clone();
+
+    *SYNC_RUNNING.write() = true;
+    spawn_forever(async move {
+        if let Err(e) = sync_server_library(clear_first, read_db, gens, source).await {
+            error!(error = %e, "server library sync failed");
+        }
+        *SYNC_RUNNING.write() = false;
+    });
+}
 
 fn normalize_album_id(id: &str) -> String {
     let parts: Vec<&str> = id.split(':').collect();
@@ -20,11 +52,12 @@ fn normalize_album_id(id: &str) -> String {
 /// the snapshot — chunked upsert + coalesced bumps keep the library view
 /// streaming in — merges manual covers, and prunes rows the server dropped.
 #[tracing::instrument(name = "library.sync", skip_all, fields(clear_first = clear_first))]
-pub async fn sync_server_library(clear_first: bool) -> Result<(), String> {
-    let read_db = consume_context::<hooks::ReadDb>();
-    let gens = hooks::db_reactivity::use_generations();
-    let active_source = use_context::<Signal<::server::source::ActiveSource>>();
-    let source = active_source.peek().clone();
+pub async fn sync_server_library(
+    clear_first: bool,
+    read_db: hooks::ReadDb,
+    gens: hooks::db_reactivity::Generations,
+    source: ::server::source::ActiveSource,
+) -> Result<(), String> {
     if !source.capabilities().sync {
         return Ok(());
     }

--- a/crates/server/src/subsonic.rs
+++ b/crates/server/src/subsonic.rs
@@ -1,6 +1,8 @@
 use rand::{RngExt, distr::Alphanumeric};
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
+use std::collections::HashSet;
+use std::sync::{LazyLock, RwLock};
 
 const SUBSONIC_API_VERSION: &str = "1.16.1";
 const CLIENT_NAME: &str = "kopuz";
@@ -43,6 +45,28 @@ struct SubsonicError {
     code: i32,
     message: String,
 }
+
+enum CallFailure {
+    Api { code: i32, message: String },
+    Transport(String),
+}
+
+impl CallFailure {
+    fn into_message(self) -> String {
+        match self {
+            CallFailure::Api { code, message } => {
+                format!("Subsonic request failed ({code}): {message}")
+            }
+            CallFailure::Transport(message) => message,
+        }
+    }
+}
+
+/// Token auth unsupported (41), mechanism (42, 43). Not 40: bad password.
+const AUTH_REJECTED_CODES: [i32; 3] = [41, 42, 43];
+
+/// Global so the throwaway clients behind the URL builders see it too.
+static LEGACY_AUTH_SERVERS: LazyLock<RwLock<HashSet<String>>> = LazyLock::new(Default::default);
 
 pub(crate) struct SubsonicClient {
     http_client: reqwest::Client,
@@ -617,6 +641,14 @@ impl SubsonicClient {
     }
 
     fn auth_params(&self) -> Vec<(String, String)> {
+        if self.uses_legacy_auth() {
+            self.legacy_auth_params()
+        } else {
+            self.token_auth_params()
+        }
+    }
+
+    fn token_auth_params(&self) -> Vec<(String, String)> {
         let salt = self.random_salt();
         let token_input = format!("{}{}", self.password, salt);
         let token = format!("{:x}", md5::compute(token_input));
@@ -629,6 +661,36 @@ impl SubsonicClient {
             ("c".to_string(), CLIENT_NAME.to_string()),
             ("f".to_string(), "json".to_string()),
         ]
+    }
+
+    fn legacy_auth_params(&self) -> Vec<(String, String)> {
+        vec![
+            ("u".to_string(), self.username.clone()),
+            (
+                "p".to_string(),
+                format!("enc:{}", hex::encode(self.password.as_bytes())),
+            ),
+            ("v".to_string(), SUBSONIC_API_VERSION.to_string()),
+            ("c".to_string(), CLIENT_NAME.to_string()),
+            ("f".to_string(), "json".to_string()),
+        ]
+    }
+
+    fn legacy_auth_key(&self) -> String {
+        format!("{}\n{}", self.base_url, self.username)
+    }
+
+    fn uses_legacy_auth(&self) -> bool {
+        LEGACY_AUTH_SERVERS
+            .read()
+            .map(|servers| servers.contains(&self.legacy_auth_key()))
+            .unwrap_or(false)
+    }
+
+    fn remember_legacy_auth(&self) {
+        if let Ok(mut servers) = LEGACY_AUTH_SERVERS.write() {
+            servers.insert(self.legacy_auth_key());
+        }
     }
 
     fn random_salt(&self) -> String {
@@ -652,41 +714,77 @@ impl SubsonicClient {
     async fn call_within<T: DeserializeOwned + Default>(
         &self,
         endpoint: &str,
-        mut extra_params: Vec<(String, String)>,
+        extra_params: Vec<(String, String)>,
         timeout: std::time::Duration,
     ) -> Result<T, String> {
         let url = format!("{}/rest/{}", self.base_url, endpoint);
 
-        let mut params = self.auth_params();
-        params.append(&mut extra_params);
+        let first = self
+            .request::<T>(&url, self.auth_params(), &extra_params, timeout)
+            .await;
+
+        let retry_auth = matches!(
+            &first,
+            Err(CallFailure::Api { code, .. })
+                if AUTH_REJECTED_CODES.contains(code) && !self.uses_legacy_auth()
+        );
+        if !retry_auth {
+            return first.map_err(CallFailure::into_message);
+        }
+
+        tracing::debug!("token auth rejected, retrying with the legacy password scheme");
+        let retry = self
+            .request::<T>(&url, self.legacy_auth_params(), &extra_params, timeout)
+            .await;
+        if retry.is_ok() {
+            self.remember_legacy_auth();
+        }
+        retry.map_err(CallFailure::into_message)
+    }
+
+    async fn request<T: DeserializeOwned + Default>(
+        &self,
+        url: &str,
+        mut params: Vec<(String, String)>,
+        extra_params: &[(String, String)],
+        timeout: std::time::Duration,
+    ) -> Result<T, CallFailure> {
+        params.extend_from_slice(extra_params);
 
         let resp = self
             .http_client
-            .get(&url)
+            .get(url)
             .query(&params)
             .timeout(timeout)
             .send()
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| CallFailure::Transport(e.to_string()))?;
 
         if !resp.status().is_success() {
-            return Err(format!("Subsonic request failed: {}", resp.status()));
+            return Err(CallFailure::Transport(format!(
+                "Subsonic request failed: {}",
+                resp.status()
+            )));
         }
 
-        let parsed: SubsonicEnvelope<T> = resp.json().await.map_err(|e| e.to_string())?;
+        let parsed: SubsonicEnvelope<T> = resp
+            .json()
+            .await
+            .map_err(|e| CallFailure::Transport(e.to_string()))?;
 
         if parsed.response.status.eq_ignore_ascii_case("ok") {
             return Ok(parsed.response.data);
         }
 
-        if let Some(err) = parsed.response.error {
-            return Err(format!(
-                "Subsonic request failed ({}): {}",
-                err.code, err.message
-            ));
+        match parsed.response.error {
+            Some(err) => Err(CallFailure::Api {
+                code: err.code,
+                message: err.message,
+            }),
+            None => Err(CallFailure::Transport(
+                "Subsonic request failed with unknown error".to_string(),
+            )),
         }
-
-        Err("Subsonic request failed with unknown error".to_string())
     }
 }
 
@@ -795,5 +893,66 @@ mod tests {
                 .iter()
                 .any(|ext| ext.name == SONIC_SIMILARITY_EXTENSION)
         );
+    }
+
+    #[test]
+    fn legacy_auth_params_hex_encode_the_password() {
+        let client = SubsonicClient::new("https://music.example.test", "user", "password");
+        let params = client.legacy_auth_params();
+
+        let p = params.iter().find(|(k, _)| k == "p").map(|(_, v)| v);
+        assert_eq!(p, Some(&"enc:70617373776f7264".to_string()));
+        assert!(!params.iter().any(|(k, _)| k == "t" || k == "s"));
+    }
+
+    async fn serve_legacy_only(listener: tokio::net::TcpListener, requests: usize) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        for _ in 0..requests {
+            let (mut sock, _) = listener.accept().await.expect("accept");
+            let mut req = Vec::new();
+            let mut buf = [0u8; 1024];
+            while !req.windows(4).any(|w| w == b"\r\n\r\n") {
+                let n = sock.read(&mut buf).await.expect("read");
+                if n == 0 {
+                    break;
+                }
+                req.extend_from_slice(&buf[..n]);
+            }
+            let req = String::from_utf8_lossy(&req);
+            let body = if req.contains("&t=") {
+                r#"{"subsonic-response":{"status":"failed","version":"1.16.1","error":{"code":41,"message":"Token-based authentication not supported"}}}"#
+            } else if req.contains("p=enc%3A70617373776f7264") {
+                r#"{"subsonic-response":{"status":"ok","version":"1.16.1"}}"#
+            } else {
+                r#"{"subsonic-response":{"status":"failed","version":"1.16.1","error":{"code":40,"message":"Wrong username or password"}}}"#
+            };
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            sock.write_all(resp.as_bytes()).await.expect("write");
+        }
+    }
+
+    #[tokio::test]
+    async fn token_rejection_falls_back_to_legacy_password_auth() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        let server = tokio::spawn(serve_legacy_only(listener, 2));
+
+        let client = SubsonicClient::new(&format!("http://{addr}"), "user", "password");
+        client.ping().await.expect("fallback should succeed");
+
+        let url = SubsonicClient::new(&format!("http://{addr}"), "user", "password")
+            .stream_url("song-1")
+            .expect("stream url");
+        assert!(url.contains("p=enc%3A70617373776f7264"));
+        assert!(!url.contains("&t="));
+
+        server.await.expect("server task");
     }
 }

--- a/crates/server/src/subsonic.rs
+++ b/crates/server/src/subsonic.rs
@@ -62,8 +62,8 @@ impl CallFailure {
     }
 }
 
-/// Token auth unsupported (41), mechanism (42, 43). Not 40: bad password.
-const AUTH_REJECTED_CODES: [i32; 3] = [41, 42, 43];
+/// Bad credentials (40), token auth unsupported (41), mechanism (42, 43).
+const AUTH_REJECTED_CODES: [i32; 4] = [40, 41, 42, 43];
 
 /// Global so the throwaway clients behind the URL builders see it too.
 static LEGACY_AUTH_SERVERS: LazyLock<RwLock<HashSet<String>>> = LazyLock::new(Default::default);
@@ -641,11 +641,17 @@ impl SubsonicClient {
     }
 
     fn auth_params(&self) -> Vec<(String, String)> {
-        if self.uses_legacy_auth() {
+        if self.uses_legacy_auth() && self.allows_legacy_auth() {
             self.legacy_auth_params()
         } else {
             self.token_auth_params()
         }
+    }
+
+    /// `p=enc:` is reversible and rides in the query string, so it is never
+    /// constructed or sent for a non-HTTPS base URL.
+    fn allows_legacy_auth(&self) -> bool {
+        self.base_url.starts_with("https://")
     }
 
     fn token_auth_params(&self) -> Vec<(String, String)> {
@@ -729,6 +735,12 @@ impl SubsonicClient {
                 if AUTH_REJECTED_CODES.contains(code) && !self.uses_legacy_auth()
         );
         if !retry_auth {
+            return first.map_err(CallFailure::into_message);
+        }
+        if !self.allows_legacy_auth() {
+            tracing::warn!(
+                "server rejected token auth; not falling back over plain http, the legacy scheme would put the password in the URL"
+            );
             return first.map_err(CallFailure::into_message);
         }
 
@@ -905,10 +917,15 @@ mod tests {
         assert!(!params.iter().any(|(k, _)| k == "t" || k == "s"));
     }
 
-    async fn serve_legacy_only(listener: tokio::net::TcpListener, requests: usize) {
+    /// A server that refuses every credential with `code`, recording what it saw.
+    async fn serve_rejecting(
+        listener: tokio::net::TcpListener,
+        code: i32,
+        seen: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    ) {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-        for _ in 0..requests {
+        loop {
             let (mut sock, _) = listener.accept().await.expect("accept");
             let mut req = Vec::new();
             let mut buf = [0u8; 1024];
@@ -919,14 +936,13 @@ mod tests {
                 }
                 req.extend_from_slice(&buf[..n]);
             }
-            let req = String::from_utf8_lossy(&req);
-            let body = if req.contains("&t=") {
-                r#"{"subsonic-response":{"status":"failed","version":"1.16.1","error":{"code":41,"message":"Token-based authentication not supported"}}}"#
-            } else if req.contains("p=enc%3A70617373776f7264") {
-                r#"{"subsonic-response":{"status":"ok","version":"1.16.1"}}"#
-            } else {
-                r#"{"subsonic-response":{"status":"failed","version":"1.16.1","error":{"code":40,"message":"Wrong username or password"}}}"#
-            };
+            seen.lock()
+                .expect("seen lock")
+                .push(String::from_utf8_lossy(&req).into_owned());
+
+            let body = format!(
+                r#"{{"subsonic-response":{{"status":"failed","version":"1.16.1","error":{{"code":{code},"message":"rejected"}}}}}}"#
+            );
             let resp = format!(
                 "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                 body.len(),
@@ -936,23 +952,61 @@ mod tests {
         }
     }
 
+    /// The legacy scheme would put a reversible password on an unencrypted
+    /// wire, so a plain-http server that refuses the token gets no second try.
     #[tokio::test]
-    async fn token_rejection_falls_back_to_legacy_password_auth() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind");
-        let addr = listener.local_addr().expect("local addr");
-        let server = tokio::spawn(serve_legacy_only(listener, 2));
+    async fn plain_http_never_sends_the_legacy_password() {
+        for code in [41, 40] {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind");
+            let addr = listener.local_addr().expect("local addr");
+            let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            tokio::spawn(serve_rejecting(listener, code, seen.clone()));
 
-        let client = SubsonicClient::new(&format!("http://{addr}"), "user", "password");
-        client.ping().await.expect("fallback should succeed");
+            let client = SubsonicClient::new(&format!("http://{addr}"), "user", "password");
+            let err = client
+                .ping()
+                .await
+                .expect_err("plain http must not fall back");
+            assert!(err.contains(&format!("({code})")), "{err}");
 
-        let url = SubsonicClient::new(&format!("http://{addr}"), "user", "password")
-            .stream_url("song-1")
-            .expect("stream url");
-        assert!(url.contains("p=enc%3A70617373776f7264"));
-        assert!(!url.contains("&t="));
+            let seen = seen.lock().expect("seen lock");
+            assert_eq!(seen.len(), 1, "code {code} must not be retried");
+            assert!(!seen.iter().any(|req| req.contains("p=enc")));
+        }
+    }
 
-        server.await.expect("server task");
+    #[test]
+    fn sticky_legacy_auth_applies_only_over_https() {
+        let secure = SubsonicClient::new("https://secure.example.test", "user", "password");
+        let plain = SubsonicClient::new("http://plain.example.test", "user", "password");
+        secure.remember_legacy_auth();
+        plain.remember_legacy_auth();
+
+        assert!(
+            secure
+                .auth_params()
+                .iter()
+                .any(|(k, v)| k == "p" && v.starts_with("enc:"))
+        );
+        assert!(secure.stream_url("song-1").expect("url").contains("p=enc"));
+        assert!(
+            secure
+                .cover_art_url("cover-1", None)
+                .expect("url")
+                .contains("p=enc")
+        );
+
+        let plain_params = plain.auth_params();
+        assert!(!plain_params.iter().any(|(k, _)| k == "p"));
+        assert!(plain_params.iter().any(|(k, _)| k == "t"));
+        assert!(!plain.stream_url("song-1").expect("url").contains("p=enc"));
+        assert!(
+            !plain
+                .cover_art_url("cover-1", None)
+                .expect("url")
+                .contains("p=enc")
+        );
     }
 }


### PR DESCRIPTION
Subsonic sources on servers that refuse token auth now retry with the legacy password parameter. 
Fixes #666.

Nextcloud Music is an obvious case: it stores password hashes, so it can't recompute the salted token and answers everything with a 41 ("Token-based authentication not supported"). Kopuz only ever sent `t`/`s`, so ping failed and the source was dead.

### Changes made:
- **Legacy auth params** (crates/server/src/subsonic.rs): `p=enc:<hex>` instead of `t`/`s`. Hex is obfuscation, not encryption, so it's only ever used after a server has already refused the token.
- **One retry** (call_within): error codes 40, 41, 42, 43 retry once with the legacy params. Anything else, and any failure on the retry, propagates as before.
- **`CallFailure`**: transport errors split from API errors so the retry can look at the code instead of a formatted string. The `Result<T, String>` surface and the messages are unchanged.
- **Sticky per server**: a successful retry records `base_url + username` in a global set. Global rather than on the client because `stream_url` and the cover URL builders spin up throwaway clients that have to sign the same way.
- **Tests**: hex encoding, plus a loopback server that rejects `t=` with a 41 and accepts the hex password, covering the retried call and the stream URL.

The Nextcloud hint I added in #629 points at Subsonic for tags and playlists, which was advice for a path that couldn't work. My oversight; the hint is now accurate tho.

### AI Disclosure
I used Claude Fable 5 for parts of this PR, did review every line, including the fully AI-written functions. I'm capable of maintaining the changes made without it. Tho it's probably a bad sign that I left such a slip-up seeing that I authored the hint myself.

## Sanity Checking
- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
