### PR TITLE
settings: support custom Apple Music storefronts

### DIFF
--- a/crates/components/src/settings/popups.rs
+++ b/crates/components/src/settings/popups.rs
@@ -2,6 +2,11 @@ use crate::settings_items::MultiDirectoryPicker;
 use config::{Browser, MusicService};
 use dioxus::prelude::*;
 
+const APPLE_MUSIC_STOREFRONTS: &[&str] = &[
+    "us", "gb", "jp", "de", "fr", "au", "br", "mx", "kr", "nl", "it", "es", "ca", "ua", "tr",
+];
+const CUSTOM_APPLE_MUSIC_STOREFRONT: &str = "__custom";
+
 #[component]
 pub fn AddLocalSourcePopup(
     name: Signal<String>,
@@ -444,14 +449,38 @@ fn ServerServiceFields(
             div { class: "mb-2",
                 label { class: "text-xs text-white/60 block mb-1", "Storefront" }
                 select {
-                    onchange: move |e| apple_music_storefront.set(e.value()),
+                    onchange: move |e| {
+                        let storefront = e.value();
+                        apple_music_storefront.set(
+                            if storefront == CUSTOM_APPLE_MUSIC_STOREFRONT {
+                                String::new()
+                            } else {
+                                storefront
+                            },
+                        );
+                    },
                     onkeydown: move |e| e.stop_propagation(),
-                    for code in &["us", "gb", "jp", "de", "fr", "au", "br", "mx", "kr", "nl", "it", "es", "ca"] {
+                    for code in APPLE_MUSIC_STOREFRONTS {
                         option {
                             value: "{code}",
                             selected: apple_music_storefront() == *code,
                             "{code}"
                         }
+                    }
+                    option {
+                        value: CUSTOM_APPLE_MUSIC_STOREFRONT,
+                        selected: !APPLE_MUSIC_STOREFRONTS
+                            .contains(&apple_music_storefront().as_str()),
+                        "Custom…"
+                    }
+                }
+                if !APPLE_MUSIC_STOREFRONTS.contains(&apple_music_storefront().as_str()) {
+                    input {
+                        class: "w-full mt-2",
+                        placeholder: "Storefront ID",
+                        value: "{apple_music_storefront()}",
+                        oninput: move |e| apple_music_storefront.set(e.value()),
+                        onkeydown: move |e| e.stop_propagation(),
                     }
                 }
             }

--- a/crates/pages/src/settings_actions.rs
+++ b/crates/pages/src/settings_actions.rs
@@ -442,6 +442,7 @@ pub fn add_server(
     let is_soundcloud = selected_service == MusicService::SoundCloud;
     let is_spotify = selected_service == MusicService::Spotify;
     let is_browser_signin = selected_service.uses_browser_signin();
+    let apple_music_storefront_value = apple_music_storefront().trim().to_string();
 
     if server_name().trim().is_empty() {
         error.set(Some(i18n::t("server_name_required").to_string()));
@@ -470,6 +471,11 @@ pub fn add_server(
         error.set(Some(
             "Enter your Apple Music media-user-token, or switch to browser sign-in".to_string(),
         ));
+        return;
+    }
+
+    if selected_service == MusicService::AppleMusic && apple_music_storefront_value.is_empty() {
+        error.set(Some("Enter an Apple Music storefront ID".to_string()));
         return;
     }
 
@@ -509,7 +515,7 @@ pub fn add_server(
             // previous server's token to one that is about to sign in through
             // the browser, and leave it there if that sign-in fails.
             if selected_service == MusicService::AppleMusic {
-                new_server.apple_music_storefront = apple_music_storefront();
+                new_server.apple_music_storefront = apple_music_storefront_value;
                 new_server.apple_music_language = apple_music_language();
                 if *apple_music_use_manual.peek() {
                     let manual = apple_music_manual_token();


### PR DESCRIPTION
- Add storefront selection with custom ID input
- Validate Apple Music storefronts before saving
- Apple Music operates in more regions than just the mentioned ones, thus it makes sense to let users input their country of choice (since the API for getting the storefronts is gated behind Apple's own bullshit)
- Assisted by GPT 5.6-Sol with Codex to find the proper code paths, code written was reviewed and verified by me

<!--
Please include a clear and concise description of the aim of your pull request
above this line.

If this pull request fixes an open issue, link it with `Fixes #<issue number>`.
For playback, scanning, source, packaging, or crash fixes, include the relevant
logs or reproduction steps.
-->

## Sanity Checking

<!--
Please check all that apply. These boxes help maintainers quickly understand
what you already verified and what still needs review.
-->

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
