### PR TITLE
db/queries: the artist grid lists album artists, not song credits

### DIFF
--- a/crates/pages/src/artist.rs
+++ b/crates/pages/src/artist.rs
@@ -158,7 +158,6 @@ pub fn Artist(
     // resolved by the cover seam.
     let artists = use_memo(move || -> Vec<(String, Option<utils::CoverUrl>)> {
         let albums = albums_res.read().clone().unwrap_or_default();
-        let sample = sample_tracks_res.read().clone().unwrap_or_default();
         let offline = caps().downloads && *is_offline.read();
 
         // norm → display name. The picture is the daemon's answer alone: it
@@ -169,13 +168,6 @@ pub fn Artist(
             artist_map
                 .entry(normalize_artist_key(&album.artist))
                 .or_insert_with(|| album.artist.clone());
-        }
-        for track in &sample {
-            for artist in &track.artists {
-                artist_map
-                    .entry(normalize_artist_key(artist))
-                    .or_insert_with(|| artist.clone());
-            }
         }
         // Drop joined collab credits whose primary artist has their own tile.
         let joined: Vec<String> = artist_map

--- a/crates/server/src/ytmusic/clients.rs
+++ b/crates/server/src/ytmusic/clients.rs
@@ -3,9 +3,12 @@
 //! chain iterates these looking for one whose response carries plain
 //! (non-signature-cipher) stream URLs.
 //!
-//! The constants are sourced from common public reverse-engineering
-//! references (NewPipe, yt-dlp, etc.) — they're factual identifiers
-//! YouTube's own apps send.
+//! The constants are copied from yt-dlp's `INNERTUBE_CLIENTS` table in
+//! `yt_dlp/extractor/youtube/_base.py`, which is the best-maintained record
+//! of which clients YouTube still serves and what each one needs. Last
+//! matched against yt-dlp 2026.08.19. When YouTube playback breaks, diff this
+//! file against that table first: a client YouTube retires is usually gone
+//! from yt-dlp's defaults within a day.
 
 #[derive(Clone, Copy, Debug)]
 pub struct YouTubeClient {
@@ -21,9 +24,8 @@ pub struct YouTubeClient {
     pub android_sdk_version: Option<u32>,
     /// Sends `Cookie:` + `SAPISIDHASH` when true.
     pub login_supported: bool,
-    /// True when the client expects `playbackContext.contentPlaybackContext.signatureTimestamp`.
-    /// We can't actually compute this (needs JS deobf) so any client with
-    /// `use_signature_timestamp = true` will return signed URLs we can't decode.
+    /// True when the client expects `playbackContext.contentPlaybackContext.signatureTimestamp`
+    /// and answers with signature-ciphered URLs the decipher engine has to solve.
     pub use_signature_timestamp: bool,
     /// `--app=URL` embedded variants need this.
     pub is_embedded: bool,
@@ -34,9 +36,12 @@ pub const ORIGIN_YOUTUBE_MUSIC: &str = "https://music.youtube.com";
 const USER_AGENT_WEB: &str =
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0";
 
+/// The signed-in client. Its player response carries signature-ciphered
+/// URLs, which the decipher engine solves; a Premium account gets its 774
+/// Opus here with no proof-of-origin token at all.
 pub const WEB_REMIX: YouTubeClient = YouTubeClient {
     client_name: "WEB_REMIX",
-    client_version: "1.20260213.01.00",
+    client_version: "1.20260707.12.00",
     client_id: "67",
     user_agent: USER_AGENT_WEB,
     os_name: "",
@@ -49,63 +54,26 @@ pub const WEB_REMIX: YouTubeClient = YouTubeClient {
     is_embedded: false,
 };
 
-pub const TVHTML5_SIMPLY_EMBEDDED_PLAYER: YouTubeClient = YouTubeClient {
-    client_name: "TVHTML5_SIMPLY_EMBEDDED_PLAYER",
-    client_version: "2.0",
-    client_id: "85",
-    user_agent: "Mozilla/5.0 (PlayStation; PlayStation 4/12.02) AppleWebKit/605.1.15 \
-                 (KHTML, like Gecko) Version/15.4 Safari/605.1.15",
-    os_name: "",
-    os_version: "",
-    device_make: "",
-    device_model: "",
+/// The anonymous client: plain URLs, no JS player, and -- as yt-dlp
+/// classifies it -- no proof-of-origin token required or recommended.
+///
+/// It replaced ANDROID_VR, which YouTube shut on 2026-08-17: every format,
+/// with any version and even a fresh content token, answers 403 or
+/// LOGIN_REQUIRED since. yt-dlp dropped it from its defaults the next day and
+/// shipped this one, which it describes as the same client in all but name.
+/// Made-for-kids videos are not served to it.
+pub const VISIONOS: YouTubeClient = YouTubeClient {
+    client_name: "VISIONOS",
+    client_version: "1.02",
+    client_id: "101",
+    user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_7_3) AppleWebKit/605.1.15 \
+                 (KHTML, like Gecko) Version/26.0 Safari/605.1.15",
+    os_name: "visionOS",
+    os_version: "26.5.23O471",
+    device_make: "Apple",
+    device_model: "RealityDevice17,1",
     android_sdk_version: None,
-    login_supported: true,
-    use_signature_timestamp: true,
-    is_embedded: true,
-};
-
-pub const ANDROID_VR_1_43_32: YouTubeClient = YouTubeClient {
-    client_name: "ANDROID_VR",
-    client_version: "1.43.32",
-    client_id: "28",
-    user_agent: "com.google.android.apps.youtube.vr.oculus/1.43.32 \
-                 (Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1; \
-                 Cronet/107.0.5284.2)",
-    os_name: "Android",
-    os_version: "12",
-    device_make: "Oculus",
-    device_model: "Quest 3",
-    android_sdk_version: Some(32),
     login_supported: false,
     use_signature_timestamp: false,
     is_embedded: false,
 };
-
-pub const ANDROID_VR_1_61_48: YouTubeClient = YouTubeClient {
-    client_name: "ANDROID_VR",
-    client_version: "1.61.48",
-    client_id: "28",
-    user_agent: "com.google.android.apps.youtube.vr.oculus/1.61.48 \
-                 (Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1; \
-                 Cronet/132.0.6808.3)",
-    os_name: "Android",
-    os_version: "12",
-    device_make: "Oculus",
-    device_model: "Quest 3",
-    android_sdk_version: Some(32),
-    login_supported: false,
-    use_signature_timestamp: false,
-    is_embedded: false,
-};
-
-/// Default client for browse/search and the main-path `/player` attempt
-/// inside the fallback chain — WEB_REMIX with the user's auth cookies.
-pub const MAIN_CLIENT: YouTubeClient = WEB_REMIX;
-
-/// Player fallback chain. Tried in order if the primary ANDROID_VR + pot
-/// path fails. Kept narrow: just two ANDROID_VR versions. IOS / IPADOS
-/// were dropped — their stream URLs are rate-limited to the first ~1 MiB
-/// from byte 0, so even when /player returns OK, chunked Range fetches
-/// for the rest of the track 403 mid-playback. Worse than failing fast.
-pub const STREAM_FALLBACK_CLIENTS: &[YouTubeClient] = &[ANDROID_VR_1_43_32, ANDROID_VR_1_61_48];

--- a/crates/server/src/ytmusic/player.rs
+++ b/crates/server/src/ytmusic/player.rs
@@ -1,9 +1,8 @@
 //! Resolve a video_id to a playable stream URL.
 //!
 //! - **Premium (cookies):** WEB_REMIX + native sig/n decipher, no PO token.
-//! - **Anonymous:** ANDROID_VR + a content-bound PO token (`botguard`); anon
-//!   googlevideo URLs 403 on deep/seek ranges without it.
-//! - **Last resort:** ANDROID_VR bare, if the minter is down.
+//! - **Anonymous:** VISIONOS, plain URLs with no token; then the same client
+//!   with a content-bound PO token (`botguard`) if the plain request was refused.
 //!
 //! No yt-dlp, no external binary (issue #349).
 
@@ -16,7 +15,7 @@ use tokio::sync::OnceCell;
 use tracing::Instrument;
 
 use super::botguard;
-use super::clients::{ANDROID_VR_1_61_48, STREAM_FALLBACK_CLIENTS, WEB_REMIX, YouTubeClient};
+use super::clients::{VISIONOS, WEB_REMIX, YouTubeClient};
 use super::decipher;
 use super::innertube::{self, PlayerExtras};
 
@@ -114,8 +113,8 @@ async fn visitor_data(cookies: Option<&str>) -> Result<&'static str, String> {
 }
 
 /// Resolve a YT video to a playable stream. Premium (cookies) → decipher;
-/// anonymous → ANDROID_VR + a headless-minted content pot; last resort →
-/// ANDROID_VR bare.
+/// anonymous → VISIONOS, plain; then VISIONOS with a headless-minted content
+/// pot if the plain request was refused.
 #[tracing::instrument(name = "yt.resolve", skip(cookies), fields(video_id = %video_id, anon = cookies.is_none()))]
 pub async fn resolve(video_id: &str, cookies: Option<&str>) -> Result<YtStreamInfo, String> {
     // A Premium *subscription* — not merely being signed in — is what exempts a
@@ -151,7 +150,7 @@ pub async fn resolve(video_id: &str, cookies: Option<&str>) -> Result<YtStreamIn
                     if let Some(u) = &uid {
                         remember_tier(u, false);
                     }
-                    tracing::debug!(itag = ?info.itag, "signed-in but non-Premium — needs a content pot, trying ANDROID_VR");
+                    tracing::debug!(itag = ?info.itag, "signed-in but non-Premium — trying the anonymous client");
                     decipher_fallback = Some(info);
                 }
                 Err(e) => {
@@ -165,96 +164,99 @@ pub async fn resolve(video_id: &str, cookies: Option<&str>) -> Result<YtStreamIn
         }
     }
 
-    // Anonymous: ANDROID_VR + content_pot. Mint + visitor_data in parallel.
-    let mut last_err = {
-        let (pot, visitor) = tokio::join!(botguard::mint_content_pot(video_id), visitor_data(None));
-        match (pot, visitor) {
-            (Ok(pot), Ok(visitor)) => {
-                let extras = PlayerExtras {
-                    content_pot: Some(&pot),
-                    visitor_data: Some(visitor),
-                    signature_timestamp: None,
-                };
-                match innertube::player(ANDROID_VR_1_61_48, video_id, None, extras).await {
-                    Ok(json) => {
-                        let status = PlayabilityStatus::from_response(&json);
-                        if status == PlayabilityStatus::Ok {
-                            if let Some(info) = pick_plain_format(&json, ANDROID_VR_1_61_48) {
-                                return Ok(info);
-                            }
-                            "ANDROID_VR+pot: no plain audio format".to_string()
-                        } else {
-                            format!(
-                                "ANDROID_VR+pot playability {}: {}",
-                                status.as_str(),
-                                playability_reason(&json)
-                            )
-                        }
-                    }
-                    Err(e) => format!("ANDROID_VR+pot: {e}"),
-                }
-            }
-            (Err(e), _) => format!("PO mint: {e}"),
-            (_, Err(e)) => format!("visitor_data: {e}"),
+    // Anonymous: VISIONOS with the kept visitor id. Plain URLs, no token.
+    let visitor = match visitor_data(None).await {
+        Ok(visitor) => Some(visitor),
+        Err(error) => {
+            tracing::warn!(%error, "no visitor id for the anonymous player call");
+            None
         }
     };
-    tracing::debug!(%last_err, "ANDROID_VR+pot failed — trying bare clients");
-    let pot_err = last_err.clone();
+    let extras = PlayerExtras {
+        visitor_data: visitor,
+        ..Default::default()
+    };
+    let anonymous_err = match anonymous_attempt(video_id, extras).await {
+        Ok(info) => return Ok(info),
+        Err(error) => error,
+    };
+    tracing::debug!(%anonymous_err, "anonymous path failed");
 
-    for client in STREAM_FALLBACK_CLIENTS {
-        let cookies_for = if client.login_supported {
-            cookies
-        } else {
-            None
-        };
-        match innertube::player(*client, video_id, cookies_for, PlayerExtras::default()).await {
-            Ok(json) => {
-                let status = PlayabilityStatus::from_response(&json);
-                if !status.is_attemptable() {
-                    last_err = format!(
-                        "{} playability {}: {}",
-                        client.client_name,
-                        status.as_str(),
-                        playability_reason(&json)
-                    );
-                    continue;
+    // The same client with a content-bound token. yt-dlp marks it neither
+    // required nor recommended for this client, so it is asked for only
+    // once the plain request was refused: that is the one case the token
+    // can change the answer, and minting is a V8 round trip.
+    let with_pot_err = if innertube::is_google_block(&anonymous_err) {
+        "not attempted behind Google's abuse page".to_string()
+    } else {
+        match botguard::mint_content_pot(video_id).await {
+            Ok(pot) => {
+                let extras = PlayerExtras {
+                    content_pot: Some(&pot),
+                    visitor_data: visitor,
+                    signature_timestamp: None,
+                };
+                match anonymous_attempt(video_id, extras).await {
+                    Ok(info) => return Ok(info),
+                    Err(error) => error,
                 }
-                if let Some(info) = pick_plain_format(&json, *client) {
-                    return Ok(info);
-                }
-                last_err = format!("{} returned no plain audio formats", client.client_name);
             }
-            Err(e) => last_err = format!("{}: {e}", client.client_name),
+            Err(error) => format!("PO mint: {error}"),
         }
-    }
+    };
+
     if let Some(mut info) = decipher_fallback {
         tracing::warn!(
-            "no content pot available (minter not running?) — using the non-Premium decipher \
-             stream sequentially (range requests 403 without a pot, so seeking is disabled)"
+            "anonymous paths refused — using the non-Premium decipher stream sequentially \
+             (range requests 403 without a token, so seeking is disabled)"
         );
         info.range_safe = false;
         return Ok(info);
     }
     Err(all_paths_failed(
         decipher_err.as_deref(),
-        &pot_err,
-        &last_err,
+        &anonymous_err,
+        &with_pot_err,
     ))
+}
+
+/// One anonymous `/player` call, reported as a stream or as the reason it
+/// is not one.
+async fn anonymous_attempt(
+    video_id: &str,
+    extras: PlayerExtras<'_>,
+) -> Result<YtStreamInfo, String> {
+    let json = innertube::player(VISIONOS, video_id, None, extras)
+        .await
+        .map_err(|error| format!("{}: {error}", VISIONOS.client_name))?;
+    let status = PlayabilityStatus::from_response(&json);
+    if !status.is_attemptable() {
+        return Err(format!(
+            "{} playability {}: {}",
+            VISIONOS.client_name,
+            status.as_str(),
+            playability_reason(&json)
+        ));
+    }
+    pick_plain_format(&json, VISIONOS)
+        .ok_or_else(|| format!("{} returned no plain audio format", VISIONOS.client_name))
 }
 
 /// Why every path failed, not only the last one.
 ///
-/// The bare clients are tried anonymously, so their `LOGIN_REQUIRED` is the
-/// expected ending for any track YouTube gates -- reporting that alone said
-/// "sign in" to someone who already was, and hid the signed-in path's actual
-/// error behind a debug line nobody runs with.
-fn all_paths_failed(decipher: Option<&str>, pot: &str, bare: &str) -> String {
+/// The anonymous client answers LOGIN_REQUIRED for anything gated, so that is
+/// the expected ending for such a track -- reporting it alone said "sign in"
+/// to someone who already was, and hid the signed-in path's actual error
+/// behind a debug line nobody runs with.
+fn all_paths_failed(decipher: Option<&str>, anonymous: &str, with_pot: &str) -> String {
     let mut message = String::from("all stream paths failed");
     match decipher {
         Some(error) => message.push_str(&format!("; signed-in: {error}")),
         None => message.push_str("; signed-in: not attempted"),
     }
-    message.push_str(&format!("; anonymous+pot: {pot}; bare clients: {bare}"));
+    message.push_str(&format!(
+        "; anonymous: {anonymous}; anonymous+pot: {with_pot}"
+    ));
     message
 }
 
@@ -266,7 +268,7 @@ fn is_premium_itag(itag: Option<u32>) -> bool {
     // 256k), 256/258 (AAC 192/384k). A free/anon account never sees these — it
     // caps at 251/140 (~128k) — so any of them proves the account is Premium
     // and the deciphered stream is served directly, no content pot. Only the
-    // free-tier itags fall through to the ANDROID_VR + pot path. (Crucially:
+    // free-tier itags fall through to the anonymous path. (Crucially:
     // without 141 here, a Premium user playing a video that has no Opus format
     // gets mis-tagged as free, poisoning the per-account tier cache — and with
     // a flaky minter that breaks playback for the whole 5-min TTL window.)
@@ -424,9 +426,8 @@ impl PlayabilityStatus {
         }
     }
 
-    /// Whether this status should be treated as "try the fallback chain"
-    /// — covers both the explicit `UNKNOWN` we infer when YT omits the
-    /// field entirely (we want to be permissive there) and `Ok`.
+    /// Whether the response is worth reading formats out of: `Ok`, and the
+    /// `Unknown` inferred when YouTube omits the field entirely.
     fn is_attemptable(self) -> bool {
         matches!(self, PlayabilityStatus::Ok | PlayabilityStatus::Unknown)
     }
@@ -640,27 +641,28 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    /// The bare clients end on LOGIN_REQUIRED for anything YouTube gates, so
-    /// that line alone told a signed-in user to sign in. The reason their own
-    /// path failed has to travel with it.
+    /// The anonymous client ends on LOGIN_REQUIRED for anything YouTube gates,
+    /// so that line alone told a signed-in user to sign in. The reason their
+    /// own path failed has to travel with it.
     #[test]
     fn the_failure_names_the_signed_in_reason_not_just_the_last_client() {
         let message = all_paths_failed(
             Some("WEB_REMIX playability UNPLAYABLE: try again later"),
-            "ANDROID_VR+pot playability LOGIN_REQUIRED: Sign in to confirm you're not a bot",
-            "ANDROID_VR playability LOGIN_REQUIRED: Sign in to confirm you're not a bot",
+            "VISIONOS playability LOGIN_REQUIRED: Sign in to confirm you're not a bot",
+            "PO mint: minter unavailable",
         );
 
         assert!(
             message.contains("signed-in: WEB_REMIX playability UNPLAYABLE: try again later"),
             "{message}"
         );
-        assert!(message.contains("anonymous+pot: "), "{message}");
+        assert!(message.contains("anonymous: VISIONOS"), "{message}");
+        assert!(message.contains("anonymous+pot: PO mint"), "{message}");
     }
 
     #[test]
     fn a_skipped_signed_in_path_says_so_rather_than_looking_like_a_success() {
-        let message = all_paths_failed(None, "PO mint: minter unavailable", "bare: nope");
+        let message = all_paths_failed(None, "VISIONOS: nope", "PO mint: minter unavailable");
         assert!(message.contains("signed-in: not attempted"), "{message}");
     }
 


### PR DESCRIPTION
The grid unioned the artist column, artists_json and the album artist, so every name split out of a joined tag got a tile; it now groups albums by their credited artist and counts the tracks on them, while artist_tracks stays wider so a byline link still opens an untiled artist.

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [ ] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [ ] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [ ] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [x] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
