### PR TITLE
various: order Recently Added by when the music was actually added

### DIFF
--- a/crates/db/.sqlx/query-08a299080da0d92e078fef79cc83ed5b5a75e11f991670999966c9fca8facc7e.json
+++ b/crates/db/.sqlx/query-08a299080da0d92e078fef79cc83ed5b5a75e11f991670999966c9fca8facc7e.json
@@ -1,0 +1,56 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT a.source_album_id, a.title, a.artist, a.genre, a.year, a.cover_path, a.manual_cover FROM albums a JOIN tracks t ON t.source = a.source AND t.source_album_id = a.source_album_id WHERE a.source = ?1 GROUP BY a.rowid_pk ORDER BY MAX(t.added_at) DESC, MAX(t.rowid_pk) DESC LIMIT ?2",
+  "describe": {
+    "columns": [
+      {
+        "name": "source_album_id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "title",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "artist",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "genre",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "year",
+        "ordinal": 4,
+        "type_info": "Integer"
+      },
+      {
+        "name": "cover_path",
+        "ordinal": 5,
+        "type_info": "Text"
+      },
+      {
+        "name": "manual_cover",
+        "ordinal": 6,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "08a299080da0d92e078fef79cc83ed5b5a75e11f991670999966c9fca8facc7e"
+}

--- a/crates/db/.sqlx/query-70b448aa97a62261b67d1d5d659fbec3a482d2946e1a94c0015566ebde48c508.json
+++ b/crates/db/.sqlx/query-70b448aa97a62261b67d1d5d659fbec3a482d2946e1a94c0015566ebde48c508.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE tracks SET added_at = ?3 WHERE source = ?1 AND track_key = ?2 AND added_at = 0",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "70b448aa97a62261b67d1d5d659fbec3a482d2946e1a94c0015566ebde48c508"
+}

--- a/crates/db/migrations/20260911000000_tracks_added_at.sql
+++ b/crates/db/migrations/20260911000000_tracks_added_at.sql
@@ -1,0 +1,6 @@
+-- "Date added" for a track, as unix seconds. The scan stamps local rows once
+-- with the file's birth time (its mtime where the filesystem records no birth
+-- time). 0 means unstamped: a server row, or a library not rescanned since this
+-- migration. Both orderings fall back to rowid_pk for those.
+ALTER TABLE tracks ADD COLUMN added_at INTEGER NOT NULL DEFAULT 0;
+CREATE INDEX idx_tracks_added ON tracks(source, added_at);

--- a/crates/db/src/backend/mod.rs
+++ b/crates/db/src/backend/mod.rs
@@ -190,6 +190,14 @@ impl ReadStore for Native {
         queries::albums(&self.pool(), source).await
     }
 
+    async fn albums_recently_added(
+        &self,
+        source: &crate::Source,
+        limit: u32,
+    ) -> Result<Vec<reader::Album>, DbError> {
+        queries::albums_recently_added(&self.pool(), source, limit).await
+    }
+
     async fn load_queue(&self) -> Result<crate::QueueSnapshot, DbError> {
         dump::load_queue(&self.pool()).await
     }
@@ -431,6 +439,14 @@ impl Storage for Native {
         albums: &[reader::Album],
     ) -> Result<(), DbError> {
         writes::upsert_albums(&self.pool(), source, albums).await
+    }
+
+    async fn stamp_added_at(
+        &self,
+        source: &crate::Source,
+        stamps: &[(String, i64)],
+    ) -> Result<(), DbError> {
+        writes::stamp_added_at(&self.pool(), source, stamps).await
     }
 
     async fn set_favorite(&self, server_id: &str, ref_: &str, on: bool) -> Result<(), DbError> {

--- a/crates/db/src/backend/queries.rs
+++ b/crates/db/src/backend/queries.rs
@@ -52,7 +52,7 @@ fn order_by(sort: &TrackSort) -> String {
         TrackSort::Title => "t.title COLLATE NOCASE".into(),
         TrackSort::Artist => "t.artist COLLATE NOCASE, t.album COLLATE NOCASE, t.track_number".into(),
         TrackSort::Album => "t.album COLLATE NOCASE, t.disc_number, t.track_number".into(),
-        TrackSort::DateAdded => "t.rowid_pk DESC".into(),
+        TrackSort::DateAdded => "t.added_at DESC, t.rowid_pk DESC".into(),
         TrackSort::PlayCount => "COALESCE(lc.count, 0) DESC, t.title COLLATE NOCASE".into(),
         TrackSort::Fields(criteria) => {
             if criteria.is_empty() {
@@ -65,14 +65,20 @@ fn order_by(sort: &TrackSort) -> String {
                         config::SortDirection::Asc => "ASC",
                         config::SortDirection::Desc => "DESC",
                     };
-                    let col = match c.field {
-                        config::TrackSortField::Title => "t.title COLLATE NOCASE",
-                        config::TrackSortField::Artist => "t.artist COLLATE NOCASE",
-                        config::TrackSortField::Album => "t.album COLLATE NOCASE",
-                        config::TrackSortField::Duration => "t.duration",
-                        config::TrackSortField::DateAdded => "t.rowid_pk",
+                    // A field may span more than one column (date added falls
+                    // back to insertion order), and each needs its own direction.
+                    let fields: &[&str] = match c.field {
+                        config::TrackSortField::Title => &["t.title COLLATE NOCASE"],
+                        config::TrackSortField::Artist => &["t.artist COLLATE NOCASE"],
+                        config::TrackSortField::Album => &["t.album COLLATE NOCASE"],
+                        config::TrackSortField::Duration => &["t.duration"],
+                        config::TrackSortField::DateAdded => &["t.added_at", "t.rowid_pk"],
                     };
-                    format!("{col} {dir}")
+                    fields
+                        .iter()
+                        .map(|col| format!("{col} {dir}"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
                 })
                 .collect();
             // Stable tail so rows equal on every criterion keep album order.
@@ -358,6 +364,38 @@ pub async fn albums(pool: &SqlitePool, source: &Source) -> Result<Vec<Album>, Db
         "SELECT source_album_id, title, artist, genre, year, cover_path, manual_cover \
          FROM albums WHERE source = ?1 ORDER BY artist COLLATE NOCASE, title COLLATE NOCASE",
         src
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().map(Into::into).collect())
+}
+
+/// Albums ordered by the newest track they hold, newest first, on the same
+/// `added_at`-then-insertion order [`TrackSort::DateAdded`] uses. An album is
+/// recent when its music is, not when its row happened to be written, and
+/// ordering on the tracks is also what lets music added to an album Kopuz
+/// already knows pull that album back up.
+///
+/// [`TrackSort::DateAdded`]: crate::TrackSort::DateAdded
+pub async fn albums_recently_added(
+    pool: &SqlitePool,
+    source: &Source,
+    limit: u32,
+) -> Result<Vec<Album>, DbError> {
+    let src = source.as_str();
+    let limit = limit as i64;
+    let rows = sqlx::query_as!(
+        AlbumRow,
+        "SELECT a.source_album_id, a.title, a.artist, a.genre, a.year, a.cover_path, \
+                a.manual_cover \
+         FROM albums a JOIN tracks t \
+           ON t.source = a.source AND t.source_album_id = a.source_album_id \
+         WHERE a.source = ?1 \
+         GROUP BY a.rowid_pk \
+         ORDER BY MAX(t.added_at) DESC, MAX(t.rowid_pk) DESC \
+         LIMIT ?2",
+        src,
+        limit
     )
     .fetch_all(pool)
     .await?;

--- a/crates/db/src/backend/writes.rs
+++ b/crates/db/src/backend/writes.rs
@@ -78,6 +78,36 @@ pub async fn upsert_tracks(
     Ok(())
 }
 
+/// Stamp each `(track_key, unix_secs)` as the track's date added. Only rows that
+/// have never been stamped are touched, so the value survives everything that
+/// rewrites a file afterwards: a tag edit bumping the mtime must not make a
+/// track look freshly added.
+#[tracing::instrument(skip_all, fields(count = stamps.len(), source = %source.as_str()))]
+pub async fn stamp_added_at(
+    pool: &SqlitePool,
+    source: &Source,
+    stamps: &[(String, i64)],
+) -> Result<(), DbError> {
+    if stamps.is_empty() {
+        return Ok(());
+    }
+    let src = source.as_str();
+    let mut tx = pool.begin().await?;
+    for (track_key, added_at) in stamps {
+        sqlx::query!(
+            "UPDATE tracks SET added_at = ?3 \
+             WHERE source = ?1 AND track_key = ?2 AND added_at = 0",
+            src,
+            track_key,
+            added_at
+        )
+        .execute(&mut *tx)
+        .await?;
+    }
+    tx.commit().await?;
+    Ok(())
+}
+
 #[tracing::instrument(skip_all, fields(count = albums.len(), source = %source.as_str()))]
 pub async fn upsert_albums(
     pool: &SqlitePool,

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -237,6 +237,16 @@ pub trait ReadStore: Send + Sync {
     /// All albums for a source, ordered by artist then title.
     async fn albums(&self, source: &Source) -> Result<Vec<reader::Album>, DbError>;
 
+    /// At most `limit` albums for a source, most recently added first, on the
+    /// same order as [`TrackSort::DateAdded`]. It is its own query because
+    /// [`ReadStore::albums`] sorts alphabetically, an order no amount of
+    /// reshuffling in the caller can turn into recency.
+    async fn albums_recently_added(
+        &self,
+        source: &Source,
+        limit: u32,
+    ) -> Result<Vec<reader::Album>, DbError>;
+
     /// Reconstruct the queue/progress snapshot from the `queue_state` row.
     async fn load_queue(&self) -> Result<QueueSnapshot, DbError>;
 
@@ -521,6 +531,15 @@ pub trait Storage: ReadStore {
     /// Batch upsert albums for a source (one transaction).
     async fn upsert_albums(&self, source: &Source, albums: &[reader::Album])
     -> Result<(), DbError>;
+
+    /// Record when each `(track_key, unix_secs)` track was added, for the
+    /// listings that sort by date added. Rows already stamped keep their value,
+    /// so this is safe to call on every scan.
+    async fn stamp_added_at(
+        &self,
+        source: &Source,
+        stamps: &[(String, i64)],
+    ) -> Result<(), DbError>;
 }
 
 /// Cheap-`Clone` handle to the active storage backend, shared via Dioxus context.

--- a/crates/db/tests/queries.rs
+++ b/crates/db/tests/queries.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 use config::{SortCriterion, SortDirection, TrackSortField};
 use db::{Page, Source, TrackFilter, TrackSort};
+use reader::models::{Album, Track, TrackId};
 use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::{ConnectOptions, Executor};
 
@@ -173,6 +174,111 @@ async fn windowed_queries_over_20k_tracks() {
 
     // Reconstructed identity is a local path.
     assert!(matches!(page[0].id, reader::models::TrackId::Local(_)));
+
+    let _ = std::fs::remove_dir_all(db_path.parent().unwrap());
+}
+
+fn album(id: &str, title: &str, artist: &str) -> Album {
+    Album {
+        id: id.into(),
+        title: title.into(),
+        artist: artist.into(),
+        genre: String::new(),
+        year: 2000,
+        cover_path: None,
+        manual_cover: false,
+    }
+}
+
+fn track(path: &str, album_id: &str) -> Track {
+    Track {
+        id: TrackId::Local(PathBuf::from(path)),
+        cover: None,
+        album_id: album_id.into(),
+        title: path.into(),
+        artist: "Artist".into(),
+        album: album_id.into(),
+        duration: 1,
+        khz: 44100,
+        bitrate: 900,
+        track_number: Some(1),
+        disc_number: Some(1),
+        musicbrainz_release_id: None,
+        musicbrainz_recording_id: None,
+        musicbrainz_track_id: None,
+        playlist_item_id: None,
+        artists: Vec::new(),
+    }
+}
+
+/// Recently-added is its own ordering, not the album listing read backwards:
+/// the listing is alphabetical, so reversing it only ever surfaces the end of
+/// the alphabet (issue #691, where a CJK-heavy library saw the same albums no
+/// matter what was scanned).
+#[tokio::test]
+async fn recently_added_albums_order_by_date_added() {
+    let db_path = unique_db();
+    let db = db::init(&db_path).await.unwrap();
+
+    // Written oldest-first, and deliberately neither alphabetical nor its
+    // reverse, so neither ordering can pass by accident.
+    for (id, artist) in [("bee", "Bea"), ("cee", "Cara"), ("ann", "Ann")] {
+        db.upsert_albums(&Source::Local, &[album(id, id, artist)])
+            .await
+            .unwrap();
+        db.upsert_tracks(&Source::Local, &[track(&format!("/music/{id}.flac"), id)])
+            .await
+            .unwrap();
+    }
+
+    let ids =
+        |albums: Vec<reader::Album>| -> Vec<String> { albums.into_iter().map(|a| a.id).collect() };
+
+    // Unstamped rows (a library not rescanned since the added_at migration, or
+    // any server source) still fall back to insertion order.
+    assert_eq!(
+        ids(db.albums_recently_added(&Source::Local, 10).await.unwrap()),
+        ["ann", "cee", "bee"]
+    );
+    assert_eq!(
+        ids(db.albums_recently_added(&Source::Local, 2).await.unwrap()),
+        ["ann", "cee"]
+    );
+
+    // A stamp outranks insertion order, and it is the album's newest track that
+    // decides: stamping the oldest album's track pulls that album to the front.
+    db.stamp_added_at(&Source::Local, &[("/music/bee.flac".into(), 1_700_000_000)])
+        .await
+        .unwrap();
+    assert_eq!(
+        ids(db.albums_recently_added(&Source::Local, 10).await.unwrap()),
+        ["bee", "ann", "cee"]
+    );
+
+    // Stamps are written once: a rescan after a tag edit bumped the file's
+    // mtime must not make old music look new.
+    db.stamp_added_at(&Source::Local, &[("/music/cee.flac".into(), 1_800_000_000)])
+        .await
+        .unwrap();
+    db.stamp_added_at(&Source::Local, &[("/music/cee.flac".into(), 1_900_000_000)])
+        .await
+        .unwrap();
+    let filter = TrackFilter {
+        sort: TrackSort::DateAdded,
+        ..TrackFilter::new(Source::Local)
+    };
+    let by_date = db
+        .tracks_page(
+            &filter,
+            Page {
+                offset: 0,
+                limit: 3,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(by_date[0].title, "/music/cee.flac");
+    assert_eq!(by_date[1].title, "/music/bee.flac");
 
     let _ = std::fs::remove_dir_all(db_path.parent().unwrap());
 }

--- a/crates/hooks/src/use_db_queries.rs
+++ b/crates/hooks/src/use_db_queries.rs
@@ -334,6 +334,36 @@ pub fn use_artist_images() -> Resource<db::ArtistImages> {
     })
 }
 
+/// The `limit` most recently added albums for a source. Tracked against the
+/// tracks table as well as the albums one: the order comes from each album's
+/// newest track, so a scan that only adds tracks to a known album still moves
+/// it up.
+pub fn use_recently_added_albums(source: Memo<Source>, limit: u32) -> Resource<Vec<reader::Album>> {
+    let db = use_context::<ReadDb>();
+    let gens = use_generations();
+    use_resource(move || {
+        let _ = gens.generation(Table::Albums);
+        let _ = gens.generation(Table::Tracks);
+        let (db, s) = (db.clone(), source());
+        let span = tracing::info_span!(
+            "query.albums_recently_added",
+            source = s.as_str(),
+            rows = tracing::field::Empty
+        );
+        offload(
+            async move {
+                let rows = db
+                    .albums_recently_added(&s, limit)
+                    .await
+                    .unwrap_or_default();
+                tracing::Span::current().record("rows", rows.len());
+                rows
+            }
+            .instrument(span),
+        )
+    })
+}
+
 /// All albums for a source, re-queried when the albums table changes.
 pub fn use_albums(source: Memo<Source>) -> Resource<Vec<reader::Album>> {
     let db = use_context::<ReadDb>();

--- a/crates/kopuz/src/main.rs
+++ b/crates/kopuz/src/main.rs
@@ -78,6 +78,27 @@ fn configured_local_sources(config: &config::AppConfig) -> Vec<(config::Source, 
         .collect()
 }
 
+/// When each scanned file landed on this machine, as unix seconds: its birth
+/// time, falling back to the mtime on filesystems that do not record one. Birth
+/// time is the closer match for what "recently added" means to someone looking
+/// at their music folder, since a copy can carry the mtime it was published
+/// with but never an older birth time. Only the DB's first stamp for a track
+/// sticks, so a later tag rewrite bumping the mtime cannot resurface old music.
+fn added_at_stamps(tracks: &[reader::Track]) -> Vec<(String, i64)> {
+    tracks
+        .iter()
+        .filter_map(|track| {
+            let meta = std::fs::metadata(track.id.local_path()?).ok()?;
+            let stamped = meta.created().or_else(|_| meta.modified()).ok()?;
+            let secs = stamped
+                .duration_since(std::time::UNIX_EPOCH)
+                .ok()?
+                .as_secs();
+            Some((track.id.key().into_owned(), secs as i64))
+        })
+        .collect()
+}
+
 async fn persist_resolved_covers(
     db: &db::Db,
     source: &config::Source,
@@ -1545,6 +1566,7 @@ fn App() -> Element {
                 }
                 for chunk in current_lib.tracks.chunks(100) {
                     let _ = db.upsert_tracks(&source, chunk).await;
+                    let _ = db.stamp_added_at(&source, &added_at_stamps(chunk)).await;
                     gens.bump_coalesced(hooks::db_reactivity::Table::Tracks);
                 }
                 let _ = db.upsert_albums(&source, &current_lib.albums).await;

--- a/crates/kopuz/src/main.rs
+++ b/crates/kopuz/src/main.rs
@@ -1566,7 +1566,12 @@ fn App() -> Element {
                 }
                 for chunk in current_lib.tracks.chunks(100) {
                     let _ = db.upsert_tracks(&source, chunk).await;
-                    let _ = db.stamp_added_at(&source, &added_at_stamps(chunk)).await;
+                    if let Err(err) = db.stamp_added_at(&source, &added_at_stamps(chunk)).await {
+                        tracing::warn!(
+                            %err,
+                            "could not stamp date added; this batch keeps insertion order until a later scan stamps it"
+                        );
+                    }
                     gens.bump_coalesced(hooks::db_reactivity::Table::Tracks);
                 }
                 let _ = db.upsert_albums(&source, &current_lib.albums).await;

--- a/crates/pages/src/home_body.rs
+++ b/crates/pages/src/home_body.rs
@@ -3,7 +3,7 @@ use config::{AppConfig, ListenNowStyle, UiStyle};
 use dioxus::prelude::*;
 use hooks::use_db_queries::{
     use_active_source, use_album_tracks, use_albums, use_artist_sample_tracks, use_favorites,
-    use_playlists, use_top_genre, use_tracks_by_keys,
+    use_playlists, use_recently_added_albums, use_top_genre, use_tracks_by_keys,
 };
 use rand::rng;
 use rand::seq::SliceRandom;
@@ -51,6 +51,11 @@ fn track_cover_url(conf: &AppConfig, track: &Track) -> Option<String> {
 /// tall), so it asks for far more pixels than the 384px grid cards.
 const HERO_COVER_WIDTH: u32 = 1400;
 
+/// How many newest albums the Recently Added query pulls. The row shows 12, but
+/// untitled albums and same-title duplicates are dropped afterwards, so the
+/// window has to be wide enough to still fill it.
+const RECENTLY_ADDED_WINDOW: u32 = 64;
+
 /// The source-agnostic Home body (sections + hero). Rendered for local and any
 /// server; the active source decides the data, covers (via the source seam), the
 /// recently-played list, and offline/sync gating.
@@ -74,6 +79,7 @@ pub fn HomeBody(
     let active_card_menu = use_signal(|| None::<String>);
 
     let albums_res = use_albums(source);
+    let recently_added_res = use_recently_added_albums(source, RECENTLY_ADDED_WINDOW);
     let playlists_res = use_playlists();
     // The artist-image caches the Top Artists row resolves through (read-only:
     // home triggers no photo fetch; the Artists page's pipeline fills these).
@@ -215,10 +221,10 @@ pub fn HomeBody(
 
     let recently_added = use_memo(move || -> Vec<AlbumCard> {
         let conf = config.read();
-        let all_albums = albums_res.read().clone().unwrap_or_default();
+        let all_albums = recently_added_res.read().clone().unwrap_or_default();
         let mut unique = Vec::new();
         let mut seen = std::collections::HashSet::new();
-        for album in all_albums.iter().rev() {
+        for album in all_albums.iter() {
             if is_unknown_album(&album.title) || is_unknown_artist(&album.artist) {
                 continue;
             }


### PR DESCRIPTION
Recently Added was the alphabetical album list read backwards; albums now order by a real date-added stamp taken from each local file at scan time. Fixes #691

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [ ] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [x] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
