### PR TITLE
various: clear the shuffle and repeat highlight when they turn off

### DIFF
--- a/crates/components/src/layout/normal/showcase.rs
+++ b/crates/components/src/layout/normal/showcase.rs
@@ -193,8 +193,11 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                 div { class: "flex items-center gap-4",
                      if !props.tracks.is_empty() {
                         button {
-                            class: "w-14 h-14 rounded-full flex items-center justify-center text-slate-400 hover:text-white hover:bg-white/10 transition-colors active:scale-95",
-                            style: if *ctrl.shuffle.read() { "color: var(--color-indigo-500);" } else { "" },
+                            class: if *ctrl.shuffle.read() {
+                                "w-14 h-14 rounded-full flex items-center justify-center text-indigo-500 hover:bg-white/10 transition-colors active:scale-95"
+                            } else {
+                                "w-14 h-14 rounded-full flex items-center justify-center text-slate-400 hover:text-white hover:bg-white/10 transition-colors active:scale-95"
+                            },
                             title: if *ctrl.shuffle.read() {
                                 i18n::t("shuffle_on").to_string()
                             } else {

--- a/crates/components/src/layout/vaxry/showcase.rs
+++ b/crates/components/src/layout/vaxry/showcase.rs
@@ -173,7 +173,7 @@ pub fn ShowcaseVaxry(props: ShowcaseProps) -> Element {
                             }
                             button {
                                 class: "inline-flex items-center justify-center gap-2 h-9 px-5 rounded-full text-sm font-semibold text-white transition-opacity hover:opacity-90 active:scale-95",
-                                style: if *ctrl.shuffle.read() { "background: var(--color-indigo-500);" } else { "background: color-mix(in oklab, var(--color-indigo-500) 25%, transparent); border: 1px solid color-mix(in oklab, var(--color-indigo-500) 40%, transparent);" },
+                                style: if *ctrl.shuffle.read() { "background: var(--color-indigo-500); border: 1px solid transparent;" } else { "background: color-mix(in oklab, var(--color-indigo-500) 25%, transparent); border: 1px solid color-mix(in oklab, var(--color-indigo-500) 40%, transparent);" },
                                 onclick: move |_| {
                                     ctrl.toggle_shuffle();
                                     ctrl.play_queue_shuffled(tracks_for_shuffle.clone());

--- a/crates/components/src/playback/controls.rs
+++ b/crates/components/src/playback/controls.rs
@@ -214,7 +214,13 @@ pub enum ControlsVariant {
 struct TransportClasses {
     wrapper: &'static str,
     side: &'static str,
+    /// The on/off colour of a side toggle (shuffle, repeat) as classes, never as
+    /// an inline `style`. Dioxus merges a style attribute with what the element
+    /// already has instead of replacing it, so a style that turns the colour on
+    /// can only ever be turned off by another style naming the same property:
+    /// an empty one leaves the button lit for the rest of the session (#690).
     side_idle: &'static str,
+    side_active: &'static str,
     side_icon: &'static str,
     step: &'static str,
     step_icon: &'static str,
@@ -228,7 +234,8 @@ fn transport_classes(variant: ControlsVariant) -> TransportClasses {
         ControlsVariant::Fullscreen => TransportClasses {
             wrapper: "flex items-center justify-between w-full mb-3",
             side: "w-11 h-11 rounded-full flex items-center justify-center transition-colors active:scale-95 relative flex-shrink-0 hover:bg-white/10",
-            side_idle: "color: rgba(255,255,255,0.6);",
+            side_idle: "text-white/60 hover:text-white",
+            side_active: "text-indigo-500",
             side_icon: "text-lg",
             step: "w-14 h-14 rounded-full flex items-center justify-center text-white/90 hover:text-white hover:bg-white/10 transition-colors active:scale-95 flex-shrink-0",
             step_icon: "text-3xl",
@@ -238,8 +245,9 @@ fn transport_classes(variant: ControlsVariant) -> TransportClasses {
         },
         ControlsVariant::Bar => TransportClasses {
             wrapper: "flex items-center gap-2",
-            side: "w-9 h-9 rounded-full flex items-center justify-center text-slate-400 hover:text-white hover:bg-white/10 transition-colors active:scale-95 relative flex-shrink-0",
-            side_idle: "",
+            side: "w-9 h-9 rounded-full flex items-center justify-center hover:bg-white/10 transition-colors active:scale-95 relative flex-shrink-0",
+            side_idle: "text-slate-400 hover:text-white",
+            side_active: "text-indigo-500",
             side_icon: "text-sm",
             step: "w-10 h-10 rounded-full flex items-center justify-center text-slate-400 hover:text-white hover:bg-white/10 transition-colors active:scale-95 flex-shrink-0",
             step_icon: "text-xl",
@@ -270,8 +278,7 @@ pub fn TransportButtons(is_playing: Signal<bool>, variant: ControlsVariant) -> E
             dir: "ltr",
             style: if variant == ControlsVariant::Fullscreen { "max-width: 640px;" } else { "" },
             button {
-                class: classes.side,
-                style: if *ctrl.shuffle.read() { "color: var(--color-indigo-500);" } else { classes.side_idle },
+                class: if *ctrl.shuffle.read() { format!("{} {}", classes.side, classes.side_active) } else { format!("{} {}", classes.side, classes.side_idle) },
                 title: if *ctrl.shuffle.read() { i18n::t("shuffle_on").to_string() } else { i18n::t("shuffle_off").to_string() },
                 onclick: move |_| ctrl.toggle_shuffle(),
                 i { class: "fa-solid fa-shuffle {classes.side_icon}" }
@@ -295,10 +302,9 @@ pub fn TransportButtons(is_playing: Signal<bool>, variant: ControlsVariant) -> E
                 }
             }
             button {
-                class: classes.side,
-                style: match *ctrl.loop_mode.read() {
-                    LoopMode::None => classes.side_idle,
-                    _ => "color: var(--color-indigo-500);",
+                class: match *ctrl.loop_mode.read() {
+                    LoopMode::None => format!("{} {}", classes.side, classes.side_idle),
+                    _ => format!("{} {}", classes.side, classes.side_active),
                 },
                 title: match *ctrl.loop_mode.read() {
                     LoopMode::None => i18n::t("repeat_off").to_string(),

--- a/crates/components/src/search/genre_detail.rs
+++ b/crates/components/src/search/genre_detail.rs
@@ -121,7 +121,7 @@ pub fn SearchGenreDetail(
                                     button {
                                         class: "inline-flex items-center justify-center gap-2 h-9 px-5 rounded-full text-sm font-semibold text-white transition-opacity hover:opacity-90 active:scale-95",
                                         style: if *ctrl.shuffle.read() {
-                                            "background: var(--color-indigo-500);"
+                                            "background: var(--color-indigo-500); border: 1px solid transparent;"
                                         } else {
                                             "background: color-mix(in oklab, var(--color-indigo-500) 25%, transparent); border: 1px solid color-mix(in oklab, var(--color-indigo-500) 40%, transparent);"
                                         },

--- a/crates/kopuz/assets/tailwind.css
+++ b/crates/kopuz/assets/tailwind.css
@@ -667,6 +667,9 @@
   .max-h-48 {
     max-height: calc(var(--spacing) * 48);
   }
+  .max-h-56 {
+    max-height: calc(var(--spacing) * 56);
+  }
   .max-h-60 {
     max-height: calc(var(--spacing) * 60);
   }
@@ -1386,6 +1389,12 @@
       background-color: color-mix(in oklab, var(--color-indigo-500) 30%, transparent);
     }
   }
+  .bg-indigo-500\/70 {
+    background-color: color-mix(in srgb, oklch(58.5% 0.233 277.117) 70%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-indigo-500) 70%, transparent);
+    }
+  }
   .bg-indigo-600 {
     background-color: var(--color-indigo-600);
   }
@@ -2019,6 +2028,9 @@
   }
   .text-indigo-400 {
     color: var(--color-indigo-400);
+  }
+  .text-indigo-500 {
+    color: var(--color-indigo-500);
   }
   .text-orange-500\/80 {
     color: color-mix(in srgb, oklch(70.5% 0.213 47.604) 80%, transparent);

--- a/crates/pages/src/album.rs
+++ b/crates/pages/src/album.rs
@@ -952,8 +952,7 @@ fn YtAlbumDetail(
                         }
                         // Shuffle.
                         button {
-                            class: format!("w-11 h-11 rounded-full border flex items-center justify-center transition-colors {}", if *ctrl.shuffle.read() { "bg-white/10 border-white/30" } else { "text-slate-300 border-white/15 hover:text-white hover:border-white/30" }),
-                            style: if *ctrl.shuffle.read() { "color: var(--color-indigo-500);" } else { "" },
+                            class: format!("w-11 h-11 rounded-full border flex items-center justify-center transition-colors {}", if *ctrl.shuffle.read() { "text-indigo-500 bg-white/10 border-white/30" } else { "text-slate-300 border-white/15 hover:text-white hover:border-white/30" }),
                             title: i18n::t("shuffle").to_string(),
                             onclick: move |_| ctrl.toggle_shuffle(),
                             i { class: "fa-solid fa-shuffle" }


### PR DESCRIPTION
Dioxus merges inline styles instead of replacing them, so an empty "off" style could never clear the active color, shuffle and repeat now carry that state in the class attribute. Fixes #690

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [ ] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [x] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
